### PR TITLE
Feat/layout engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.0.3
+### [Added]
+- Canvas rendering infrastructure: `CanvasBuffer`, `BufferCell`.
+- Text component system: `TextComponent`, `TextComponentStyle`, `FontStyle`, `Colors`.
+- `RenderManager` for orchestrating component rendering and buffer flushing.
+- Unit tests for rendering and styling logic.
+
+## 0.0.2
+
+### [Added]
+- Core geometry types: `Rect`, `Size`, `Axis`, `Context`, `Position`.
+- Input event system: `InputEvent`, `MouseEvent`, `CharEvent`, etc.
+
 ## 0.0.1
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
-## 0.0.3
-### [Added]
-- Canvas rendering infrastructure: `CanvasBuffer`, `BufferCell`.
-- Text component system: `TextComponent`, `TextComponentStyle`, `FontStyle`, `Colors`.
-- `RenderManager` for orchestrating component rendering and buffer flushing.
-- Unit tests for rendering and styling logic.
+# Changelog
 
-## 0.0.2
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [Added]
-- Core geometry types: `Rect`, `Size`, `Axis`, `Context`, `Position`.
-- Input event system: `InputEvent`, `MouseEvent`, `CharEvent`, etc.
+### [0.0.2](https://github.com/primequantuM4/pixel_prompt/compare/v0.0.1...v0.0.2) (2025-06-12)
+
+
+### Features
+
+* **rendering:** implement core rendering pipeline and text components ([2e32c8d](https://github.com/primequantuM4/pixel_prompt/commit/2e32c8d94d7cba73b327fa233802ec496a47e6aa))
+
+
+### Bug Fixes
+
+* margin and size rename ([4dae080](https://github.com/primequantuM4/pixel_prompt/commit/4dae0809da0717d00292808d491422879090da07))
 
 ## 0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.3](https://github.com/primequantuM4/pixel_prompt/compare/v0.0.2...v0.0.3) (2025-06-12)
+
+
+### Features
+
+* **layout:** implement layout engine with row and column support ([299a651](https://github.com/primequantuM4/pixel_prompt/commit/299a6516b1df8609c415fe2ba52262b9bd70cbf4))
+
 ### [0.0.2](https://github.com/primequantuM4/pixel_prompt/compare/v0.0.1...v0.0.2) (2025-06-12)
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gedion Ezra Abate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/components/colors.dart
+++ b/lib/components/colors.dart
@@ -1,0 +1,53 @@
+abstract class AnsiColorType {
+  String get fg;
+  String get bg;
+}
+
+enum Colors implements AnsiColorType {
+  black(30, 40),
+  red(31, 41),
+  green(32, 42),
+  yellow(33, 43),
+  blue(34, 44),
+  magenta(35, 45),
+  cyan(36, 46),
+  white(37, 47),
+  highBlack(90, 100),
+  highRed(91, 101),
+  highGreen(92, 102),
+  highYellow(93, 103),
+  highBlue(94, 104),
+  highMagenta(95, 105),
+  highCyan(96, 106),
+  highWhite(97, 107);
+
+  final int code;
+  final int bgCode;
+  const Colors(this.code, this.bgCode);
+
+  @override
+  String get fg => '$code';
+
+  @override
+  String get bg => '$bgCode';
+}
+
+class ColorRGB implements AnsiColorType {
+  final int r, g, b;
+  const ColorRGB(this.r, this.g, this.b);
+
+  @override
+  String get fg => '38;2;$r;$g;$b';
+
+  @override
+  String get bg => '48;2;$r;$g;$b';
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ColorRGB && r == other.r && g == other.g && b == other.b;
+  }
+
+  @override
+  int get hashCode => Object.hash(r, g, b);
+}

--- a/lib/components/column.dart
+++ b/lib/components/column.dart
@@ -1,0 +1,60 @@
+import 'dart:math';
+
+import 'package:pixel_prompt/core/axis.dart';
+import 'package:pixel_prompt/core/canvas_buffer.dart';
+import 'package:pixel_prompt/core/component.dart';
+import 'package:pixel_prompt/core/position.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/core/size.dart';
+import 'package:pixel_prompt/layout_engine/layout_engine.dart';
+
+class Column extends Component with ParentComponent {
+  @override
+  final List<Component> children;
+
+  Column({required this.children});
+
+  @override
+  Size measure(Size maxSize) {
+    int totalHeight = 0;
+    int maxWidth = 0;
+
+    for (final child in children) {
+      if (child.position?.positionType == PositionType.absolute) continue;
+
+      final childSize = child.measure(maxSize);
+      totalHeight += childSize.height;
+
+      maxWidth = max(childSize.width, maxWidth);
+    }
+
+    return Size(width: maxWidth, height: totalHeight);
+  }
+
+  @override
+  void render(CanvasBuffer buffer, Rect bounds) {
+    final engine = LayoutEngine(
+      children: children,
+      direction: Axis.vertical,
+      bounds: bounds,
+    );
+
+    final positionedItems = engine.compute();
+
+    for (final item in positionedItems) {
+      item.component.render(buffer, item.rect);
+    }
+  }
+
+  @override
+  int fitHeight() {
+    // TODO: Implement once dynamic sizing (flex/grow/shrink) is supported
+    throw UnimplementedError();
+  }
+
+  @override
+  int fitWidth() {
+    // TODO: Implement once dynamic sizing (flex/grow/shrink) is supported
+    throw UnimplementedError();
+  }
+}

--- a/lib/components/font_style.dart
+++ b/lib/components/font_style.dart
@@ -1,0 +1,9 @@
+enum FontStyle {
+  bold(1),
+  italic(3),
+  underline(4),
+  strikethrough(9);
+
+  final int code;
+  const FontStyle(this.code);
+}

--- a/lib/components/row.dart
+++ b/lib/components/row.dart
@@ -1,0 +1,60 @@
+import 'dart:math';
+
+import 'package:pixel_prompt/core/axis.dart';
+import 'package:pixel_prompt/core/canvas_buffer.dart';
+import 'package:pixel_prompt/core/component.dart';
+import 'package:pixel_prompt/core/position.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/core/size.dart';
+import 'package:pixel_prompt/layout_engine/layout_engine.dart';
+
+class Row extends Component with ParentComponent {
+  @override
+  final List<Component> children;
+
+  Row({required this.children});
+
+  @override
+  Size measure(Size maxSize) {
+    int maxHeight = 0;
+    int totalWidth = 0;
+
+    for (final child in children) {
+      if (child.position?.positionType == PositionType.absolute) continue;
+
+      final childSize = child.measure(maxSize);
+      totalWidth += childSize.width;
+
+      maxHeight = max(childSize.height, maxHeight);
+    }
+
+    return Size(width: totalWidth, height: maxHeight);
+  }
+
+  @override
+  void render(CanvasBuffer buffer, Rect bounds) {
+    final engine = LayoutEngine(
+      children: children,
+      direction: Axis.horizontal,
+      bounds: bounds,
+    );
+
+    final positionedItems = engine.compute();
+
+    for (final item in positionedItems) {
+      item.component.render(buffer, item.rect);
+    }
+  }
+
+  @override
+  int fitHeight() {
+    // TODO: Implement once dynamic sizing (flex/grow/shrink) is supported
+    throw UnimplementedError();
+  }
+
+  @override
+  int fitWidth() {
+    // TODO: Implement once dynamic sizing (flex/grow/shrink) is supported
+    throw UnimplementedError();
+  }
+}

--- a/lib/components/text_component.dart
+++ b/lib/components/text_component.dart
@@ -1,0 +1,89 @@
+import 'package:pixel_prompt/components/text_component_style.dart';
+import 'package:pixel_prompt/core/canvas_buffer.dart';
+import 'package:pixel_prompt/core/component.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/core/size.dart';
+
+class TextComponent extends Component {
+  final String text;
+  final TextComponentStyle style;
+
+  TextComponent(this.text, {required this.style, super.position});
+
+  @override
+  Size measure(Size maxSize) {
+    final lines = text.split('\n');
+    final contentWidth = lines.fold(
+      0,
+      (max, line) => line.length > max ? line.length : max,
+    );
+    final contentHeight = lines.length;
+    return Size(
+      width: contentWidth + style.horizontalPadding + style.horizontalMargin,
+      height: contentHeight + style.verticalPadding + style.verticalMargin,
+    );
+  }
+
+  @override
+  void render(CanvasBuffer buffer, Rect bounds) {
+    final lines = text.split('\n');
+    int y = bounds.y + style.topPadding + style.topMargin;
+
+    for (var line in lines) {
+      int x = bounds.x + style.leftMargin + style.leftPadding;
+
+      for (int i = 0; i < style.leftPadding; i++) {
+        buffer.drawChar(
+          x - i - 1,
+          y,
+          ' ',
+          fg: style.color,
+          bg: style.bgColor,
+          styles: style.styles,
+        );
+      }
+
+      buffer.drawAt(x, y, line, style);
+
+      for (int i = 0; i < style.rightPadding; i++) {
+        buffer.drawChar(
+          x + line.length + i,
+          y,
+          ' ',
+          fg: style.color,
+          bg: style.bgColor,
+        );
+      }
+      y += 1;
+    }
+
+    final totalWidth =
+        lines.fold(0, (max, line) => line.length > max ? line.length : max) +
+        style.horizontalPadding;
+    final leftX = bounds.x + style.leftMargin;
+
+    for (int i = 0; i < style.topPadding; i++) {
+      buffer.drawAt(
+        leftX,
+        bounds.y + style.topMargin + i,
+        ' ' * totalWidth,
+        style,
+      );
+    }
+
+    for (int i = 0; i < style.bottomPadding; i++) {
+      buffer.drawAt(leftX, y + i, ' ' * totalWidth, style);
+    }
+  }
+
+  @override
+  int fitHeight() {
+    final totalLines = text.split('\n').length;
+    return style.topPadding + style.bottomPadding + totalLines;
+  }
+
+  @override
+  int fitWidth() {
+    return style.leftPadding + style.rightPadding + text.length;
+  }
+}

--- a/lib/components/text_component_style.dart
+++ b/lib/components/text_component_style.dart
@@ -6,15 +6,15 @@ class TextComponentStyle {
   AnsiColorType? bgColor;
   Set<FontStyle> styles = {};
 
-  int _paddingLeft = 0;
-  int _paddingRight = 0;
-  int _paddingTop = 0;
-  int _paddingBottom = 0;
+  int _leftPadding = 0;
+  int _rightPadding = 0;
+  int _topPadding = 0;
+  int _bottomPadding = 0;
 
-  int _marginLeft = 0;
-  int _marginRight = 0;
-  int _marginTop = 0;
-  int _marginBottom = 0;
+  int _leftMargin = 0;
+  int _rightMargin = 0;
+  int _topMargin = 0;
+  int _bottomMargin = 0;
 
   TextComponentStyle foreground(AnsiColorType color) {
     this.color = color;
@@ -47,42 +47,42 @@ class TextComponentStyle {
   }
 
   TextComponentStyle paddingTop(int padding) {
-    _paddingTop = padding;
+    _topPadding = padding;
     return this;
   }
 
   TextComponentStyle paddingLeft(int padding) {
-    _paddingLeft = padding;
+    _leftPadding = padding;
     return this;
   }
 
   TextComponentStyle paddingRight(int padding) {
-    _paddingRight = padding;
+    _rightPadding = padding;
     return this;
   }
 
   TextComponentStyle paddingBottom(int padding) {
-    _paddingBottom = padding;
+    _bottomPadding = padding;
     return this;
   }
 
   TextComponentStyle marginTop(int margin) {
-    _marginTop = margin;
+    _topMargin = margin;
     return this;
   }
 
   TextComponentStyle marginBottom(int margin) {
-    _marginBottom = margin;
+    _bottomMargin = margin;
     return this;
   }
 
   TextComponentStyle marginLeft(int margin) {
-    _marginLeft = margin;
+    _leftMargin = margin;
     return this;
   }
 
   TextComponentStyle marginRight(int margin) {
-    _marginRight = margin;
+    _rightMargin = margin;
     return this;
   }
 
@@ -96,18 +96,18 @@ class TextComponentStyle {
     return codes;
   }
 
-  int get horizontalPadding => _paddingLeft + _paddingRight;
-  int get verticalPadding => _paddingTop + _paddingBottom;
-  int get horizontalMargin => _marginLeft + _marginRight;
-  int get verticalMargin => _marginTop + _marginBottom;
+  int get horizontalPadding => _leftPadding + _rightPadding;
+  int get verticalPadding => _topPadding + _bottomPadding;
+  int get horizontalMargin => _leftMargin + _rightMargin;
+  int get verticalMargin => _topMargin + _bottomMargin;
 
-  int get leftPadding => _paddingLeft;
-  int get rightPadding => _paddingRight;
-  int get topPadding => _paddingTop;
-  int get bottomPadding => _paddingBottom;
+  int get leftPadding => _leftPadding;
+  int get rightPadding => _rightPadding;
+  int get topPadding => _topPadding;
+  int get bottomPadding => _bottomPadding;
 
-  int get leftMargin => _marginLeft;
-  int get rightMargin => _marginRight;
-  int get topMargin => _marginTop;
-  int get bottomMargin => _marginBottom;
+  int get leftMargin => _leftMargin;
+  int get rightMargin => _rightMargin;
+  int get topMargin => _topMargin;
+  int get bottomMargin => _bottomMargin;
 }

--- a/lib/components/text_component_style.dart
+++ b/lib/components/text_component_style.dart
@@ -1,0 +1,113 @@
+import 'colors.dart';
+import 'font_style.dart';
+
+class TextComponentStyle {
+  AnsiColorType? color;
+  AnsiColorType? bgColor;
+  Set<FontStyle> styles = {};
+
+  int _paddingLeft = 0;
+  int _paddingRight = 0;
+  int _paddingTop = 0;
+  int _paddingBottom = 0;
+
+  int _marginLeft = 0;
+  int _marginRight = 0;
+  int _marginTop = 0;
+  int _marginBottom = 0;
+
+  TextComponentStyle foreground(AnsiColorType color) {
+    this.color = color;
+    return this;
+  }
+
+  TextComponentStyle background(AnsiColorType color) {
+    bgColor = color;
+    return this;
+  }
+
+  TextComponentStyle bold() {
+    styles.add(FontStyle.bold);
+    return this;
+  }
+
+  TextComponentStyle italic() {
+    styles.add(FontStyle.italic);
+    return this;
+  }
+
+  TextComponentStyle underline() {
+    styles.add(FontStyle.underline);
+    return this;
+  }
+
+  TextComponentStyle strikethrough() {
+    styles.add(FontStyle.strikethrough);
+    return this;
+  }
+
+  TextComponentStyle paddingTop(int padding) {
+    _paddingTop = padding;
+    return this;
+  }
+
+  TextComponentStyle paddingLeft(int padding) {
+    _paddingLeft = padding;
+    return this;
+  }
+
+  TextComponentStyle paddingRight(int padding) {
+    _paddingRight = padding;
+    return this;
+  }
+
+  TextComponentStyle paddingBottom(int padding) {
+    _paddingBottom = padding;
+    return this;
+  }
+
+  TextComponentStyle marginTop(int margin) {
+    _marginTop = margin;
+    return this;
+  }
+
+  TextComponentStyle marginBottom(int margin) {
+    _marginBottom = margin;
+    return this;
+  }
+
+  TextComponentStyle marginLeft(int margin) {
+    _marginLeft = margin;
+    return this;
+  }
+
+  TextComponentStyle marginRight(int margin) {
+    _marginRight = margin;
+    return this;
+  }
+
+  String getStyleAnsi() {
+    final codes = [
+      if (color != null) color!.fg,
+      if (bgColor != null) bgColor!.bg,
+      for (var style in styles) style.code,
+    ].join(';');
+
+    return codes;
+  }
+
+  int get horizontalPadding => _paddingLeft + _paddingRight;
+  int get verticalPadding => _paddingTop + _paddingBottom;
+  int get horizontalMargin => _marginLeft + _marginRight;
+  int get verticalMargin => _marginTop + _marginBottom;
+
+  int get leftPadding => _paddingLeft;
+  int get rightPadding => _paddingRight;
+  int get topPadding => _paddingTop;
+  int get bottomPadding => _paddingBottom;
+
+  int get leftMargin => _marginLeft;
+  int get rightMargin => _marginRight;
+  int get topMargin => _marginTop;
+  int get bottomMargin => _marginBottom;
+}

--- a/lib/core/axis.dart
+++ b/lib/core/axis.dart
@@ -1,0 +1,1 @@
+enum Axis { horizontal, vertical }

--- a/lib/core/buffer_cell.dart
+++ b/lib/core/buffer_cell.dart
@@ -1,0 +1,36 @@
+import 'package:pixel_prompt/components/colors.dart';
+import 'package:pixel_prompt/components/font_style.dart';
+
+class BufferCell {
+  String char;
+  AnsiColorType? fg;
+  AnsiColorType? bg;
+  Set<FontStyle> styles;
+
+  BufferCell({required this.char, this.fg, this.bg, Set<FontStyle>? styles})
+    : styles = styles ?? {};
+
+  @override
+  bool operator ==(Object other) {
+    return other is BufferCell &&
+        (other.char == char &&
+            other.fg == fg &&
+            other.bg == bg &&
+            _setEquals(other.styles, styles));
+  }
+
+  void clear() {
+    char = ' ';
+    fg = null;
+    bg = null;
+    styles.clear();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(char, fg, bg, Object.hashAllUnordered(styles));
+
+  bool _setEquals(Set a, Set b) {
+    return a.length == b.length && a.containsAll(b);
+  }
+}

--- a/lib/core/canvas_buffer.dart
+++ b/lib/core/canvas_buffer.dart
@@ -1,0 +1,185 @@
+import 'dart:io';
+
+import 'package:pixel_prompt/components/colors.dart';
+import 'package:pixel_prompt/components/font_style.dart';
+import 'package:pixel_prompt/components/text_component_style.dart';
+import 'package:pixel_prompt/core/buffer_cell.dart';
+import 'package:pixel_prompt/core/rect.dart';
+
+class CanvasBuffer {
+  final int width;
+  final int height;
+
+  int cursorOriginalX = -1;
+  int cursorOriginalY = -1;
+
+  bool isFullscreen = false;
+  final List<List<BufferCell>> _screenBuffer;
+
+  CanvasBuffer({required this.width, required this.height})
+    : _screenBuffer = List.generate(
+        height,
+        (_) => List.filled(width, BufferCell(char: ' ')),
+      );
+
+  setTerminalOffset(int x, int y) {
+    cursorOriginalX = x;
+    cursorOriginalY = y;
+  }
+
+  void drawChar(
+    int x,
+    int y,
+    String char, {
+    AnsiColorType? fg,
+    AnsiColorType? bg,
+    Set<FontStyle>? styles,
+  }) {
+    if (x >= 0 && x < width && y >= 0 && y < height) {
+      final Set<FontStyle> effectiveStyle = (char.trim().isEmpty)
+          ? {}
+          : (styles ?? {});
+      _screenBuffer[y][x] = BufferCell(
+        char: char,
+        fg: fg,
+        bg: bg,
+        styles: effectiveStyle,
+      );
+    }
+  }
+
+  void drawAt(int x, int y, String data, TextComponentStyle style) {
+    for (int i = 0; i < data.length; i++) {
+      drawChar(
+        x + i,
+        y,
+        data[i],
+        fg: style.color,
+        bg: style.bgColor,
+        styles: style.styles,
+      );
+    }
+  }
+
+  void clear() {
+    for (var row in _screenBuffer) {
+      for (final cell in row) {
+        cell.clear();
+      }
+    }
+
+    stdout.write('\x1B[2J');
+    stdout.write('\x1B[H');
+  }
+
+  void clearBufferArea(Rect area) {
+    for (int y = area.y; y < area.y + area.height; y++) {
+      if (y >= _screenBuffer.length) break;
+      for (int x = area.x; x < area.x + area.width; x++) {
+        if (x >= _screenBuffer[0].length) break;
+        _screenBuffer[y][x].clear();
+      }
+    }
+  }
+
+  void flushArea(Rect area) {
+    /*
+          \x1B[2J -> clears entire screen 
+          \x1B[k -> clear from cursor to end of line
+          \x1B[1k -> clear from beginning to cursor
+          \x1B[2k -> clear entire line
+          \x1B[n;mH or \x1B[n;mf -> move cursor to row n, col m
+    */
+    final int renderX = isFullscreen ? 1 : cursorOriginalX;
+    final int renderY = isFullscreen ? 1 : cursorOriginalY;
+
+    String cursorPosition = '\x1B[$renderY;${renderX}H';
+    stdout.write(cursorPosition);
+    for (int y = area.y; y < area.y + area.height; y++) {
+      if (y > _screenBuffer.length) break;
+      for (int x = area.x; x < area.x + area.width; x++) {
+        if (x > _screenBuffer[0].length) break;
+
+        stdout.write(' ');
+      }
+    }
+  }
+
+  void render() {
+    final renderY = isFullscreen ? 1 : cursorOriginalY;
+    final renderX = isFullscreen ? 1 : cursorOriginalX;
+
+    stdout.write('\x1B[$renderY;${renderX}H');
+    for (int y = 0; y < _screenBuffer.length; y++) {
+      final row = _screenBuffer[y];
+      final buffer = StringBuffer();
+      BufferCell? lastCell;
+
+      for (final cell in row) {
+        if (lastCell == null || !_sameStyle(cell, lastCell)) {
+          buffer.write('\x1B[0');
+          buffer.write(_ansiCode(cell));
+          lastCell = cell;
+        }
+        buffer.write(cell.char);
+      }
+
+      buffer.write('\x1B[0m');
+      buffer.write('\n');
+      stdout.write(buffer.toString());
+    }
+  }
+
+  bool _sameStyle(BufferCell cell, BufferCell lastCell) {
+    return cell.fg == lastCell.fg &&
+        cell.bg == lastCell.bg &&
+        _sameSet(cell.styles, lastCell.styles);
+  }
+
+  bool _sameSet(Set<FontStyle> a, Set<FontStyle> b) {
+    if (a.length != b.length) return false;
+    for (final style in a) {
+      if (!b.contains(style)) return false;
+    }
+    return true;
+  }
+
+  String _ansiCode(BufferCell cell) {
+    final style = TextComponentStyle();
+    style.color = cell.fg;
+    style.bgColor = cell.bg;
+    style.styles = cell.styles;
+
+    final String ansiCode = style.getStyleAnsi();
+    if (ansiCode.isEmpty) return 'm';
+    return ';${ansiCode}m';
+  }
+
+  // ========== FOR TESTING PURPOSES ==========
+
+  List<List<BufferCell>> getDrawnCanvas() {
+    return _screenBuffer;
+  }
+
+  List<String> getRenderedString() {
+    List<String> renderedString = [];
+
+    for (var row in _screenBuffer) {
+      final buffer = StringBuffer();
+      BufferCell? lastCell;
+
+      for (final cell in row) {
+        if (lastCell == null || !_sameStyle(cell, lastCell)) {
+          buffer.write('\x1B[0');
+          buffer.write(_ansiCode(cell));
+          lastCell = cell;
+        }
+        buffer.write(cell.char);
+      }
+
+      buffer.write('\x1B[0m');
+      renderedString.add(buffer.toString());
+    }
+    return renderedString;
+  }
+}

--- a/lib/core/component.dart
+++ b/lib/core/component.dart
@@ -1,0 +1,31 @@
+import 'package:pixel_prompt/core/canvas_buffer.dart';
+import 'package:pixel_prompt/core/position.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/core/size.dart';
+
+abstract class Component {
+  final Position? position;
+
+  Rect? _bounds;
+
+  void setBounds(Rect bounds) {
+    _bounds = bounds;
+  }
+
+  Rect getBounds() {
+    if (_bounds == null) throw Exception("Component bounds not set yet");
+    return _bounds!;
+  }
+
+  void markDirty() {}
+  Component({this.position});
+
+  Size measure(Size maxSize);
+  int fitWidth();
+  int fitHeight();
+  void render(CanvasBuffer buffer, Rect bounds);
+}
+
+mixin ParentComponent on Component {
+  List<Component> get children;
+}

--- a/lib/core/context.dart
+++ b/lib/core/context.dart
@@ -1,0 +1,9 @@
+class Context {
+  int cursorX = -1;
+  int cursorY = -1;
+
+  setInitialCursorPosition(int x, int y) {
+    cursorX = x;
+    cursorY = y;
+  }
+}

--- a/lib/core/position.dart
+++ b/lib/core/position.dart
@@ -1,0 +1,14 @@
+class Position {
+  final int x;
+  final int y;
+  final PositionType positionType;
+
+  const Position({
+    required this.x,
+    required this.y,
+    required this.positionType,
+  });
+}
+
+enum PositionType { absolute, relative }
+

--- a/lib/core/rect.dart
+++ b/lib/core/rect.dart
@@ -1,0 +1,16 @@
+class Rect {
+    final int x;
+    final int y; 
+    final int width;
+    final int height;
+    const Rect({
+        required this.x, 
+        required this.y, 
+        required this.width, 
+        required this.height
+    });
+
+    int get right => x + width;
+    int get bottom => y + height;
+}
+

--- a/lib/core/size.dart
+++ b/lib/core/size.dart
@@ -1,0 +1,6 @@
+class Size {
+  int width;
+  int height;
+
+  Size({required this.width, required this.height});
+}

--- a/lib/events/input_event.dart
+++ b/lib/events/input_event.dart
@@ -1,0 +1,62 @@
+sealed class InputEvent {
+  const InputEvent();
+}
+
+class CharEvent extends InputEvent {
+  final String char;
+
+  const CharEvent({required this.char});
+}
+
+enum SequenceOrigin { generic, windows, linux }
+
+class SequenceEvent extends InputEvent {
+  final List<int> sequence;
+  final SequenceOrigin origin;
+
+  const SequenceEvent({
+    required this.sequence,
+    this.origin = SequenceOrigin.generic,
+  });
+}
+
+enum NavigationKeyType { tab, shiftTab, escape, unknown }
+
+class NavigationKeyEvent {
+  final NavigationKeyType type;
+
+  const NavigationKeyEvent({required this.type});
+}
+
+class TabEvent extends InputEvent {}
+
+class ShiftTabEvent extends InputEvent {}
+
+class EscapeEvent extends InputEvent {}
+
+class MouseEvent extends InputEvent {
+  final MouseEventType type;
+  final int x;
+  final int y;
+  final int button;
+
+  MouseEvent({
+    required this.type,
+    required this.x,
+    required this.y,
+    required this.button,
+  });
+
+  @override
+  String toString() {
+    return 'MouseEvent{type: $type, x: $x, y: $y, button: $button}';
+  }
+}
+
+class UnknownEvent extends InputEvent {
+  final int? byte;
+
+  const UnknownEvent({this.byte});
+}
+
+enum MouseEventType { click, release, hover, error }

--- a/lib/layout_engine/layout_engine.dart
+++ b/lib/layout_engine/layout_engine.dart
@@ -1,0 +1,116 @@
+import 'dart:math';
+
+import 'package:pixel_prompt/core/component.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/core/axis.dart';
+import 'package:pixel_prompt/core/size.dart';
+import 'package:pixel_prompt/core/position.dart';
+
+import 'positioned_component.dart';
+
+class LayoutEngine {
+  final List<Component> children;
+  final Axis direction;
+  final Rect bounds;
+  final int childGap = 1;
+
+  LayoutEngine({
+    required this.children,
+    required this.direction,
+    required this.bounds,
+  });
+
+  List<PositionedComponent> compute() {
+    int cursorX = bounds.x;
+    int cursorY = bounds.y;
+
+    final List<PositionedComponent> result = [];
+
+    for (final child in children) {
+      final size = child.measure(
+        Size(width: bounds.width, height: bounds.height),
+      );
+
+      if (child.position?.positionType == PositionType.absolute) {
+        final bounds = Rect(
+          x: child.position!.x,
+          y: child.position!.y,
+          width: size.width,
+          height: size.height,
+        );
+        result.add(PositionedComponent(component: child, rect: bounds));
+        child.setBounds(bounds);
+        continue;
+      }
+
+      final xVal = direction == Axis.vertical ? bounds.x : cursorX;
+      final yVal = direction == Axis.vertical ? cursorY : bounds.y;
+
+      final Rect childBounds;
+      if (child.position == null) {
+        childBounds = Rect(
+          x: xVal,
+          y: yVal,
+          width: size.width,
+          height: size.height,
+        );
+      } else {
+        childBounds = Rect(
+          x: xVal + child.position!.x,
+          y: yVal + child.position!.y,
+          width: size.width,
+          height: size.height,
+        );
+      }
+
+      result.add(PositionedComponent(component: child, rect: childBounds));
+      child.setBounds(childBounds);
+
+      if (direction == Axis.vertical) {
+        cursorY += size.height + childGap;
+      } else {
+        cursorX += size.width + childGap;
+      }
+    }
+
+    return result;
+  }
+
+  int fitWidth() {
+    if (children.isEmpty) return 0;
+    int requiredWidth = 0;
+
+    if (direction == Axis.horizontal) {
+      requiredWidth += ((children.length - 1) * childGap);
+    }
+
+    for (var child in children) {
+      if (direction == Axis.horizontal) {
+        requiredWidth += child.fitWidth();
+      } else {
+        requiredWidth = max(child.fitWidth(), requiredWidth);
+      }
+    }
+
+    return requiredWidth;
+  }
+
+  int fitHeight() {
+    if (children.isEmpty) return 0;
+    int requiredHeight = 0;
+
+    if (direction == Axis.vertical) {
+      requiredHeight += ((children.length - 1) * childGap);
+    }
+
+    for (var child in children) {
+      if (direction == Axis.vertical) {
+        requiredHeight += child.fitHeight();
+      } else {
+        requiredHeight = max(requiredHeight, child.fitHeight());
+      }
+    }
+
+    return requiredHeight;
+  }
+}

--- a/lib/layout_engine/positioned_component.dart
+++ b/lib/layout_engine/positioned_component.dart
@@ -1,0 +1,9 @@
+import 'package:pixel_prompt/core/component.dart';
+import 'package:pixel_prompt/core/rect.dart';
+
+class PositionedComponent {
+  Component component;
+  final Rect rect;
+
+  PositionedComponent({required this.component, required this.rect});
+}

--- a/lib/renderer/render_manager.dart
+++ b/lib/renderer/render_manager.dart
@@ -1,0 +1,27 @@
+import 'package:pixel_prompt/core/canvas_buffer.dart';
+import 'package:pixel_prompt/core/components.dart';
+
+class RenderManager {
+  final CanvasBuffer buffer;
+
+  final List<Component> _dirtyComponents = [];
+
+  RenderManager({required this.buffer});
+
+  void markDirty(Component comp) => _dirtyComponents.add(comp);
+
+  void requestRedraw() {
+    for (var component in _dirtyComponents) {
+      buffer.clearBufferArea(component.getBounds());
+      buffer.flushArea(component.getBounds());
+      component.render(buffer, component.getBounds());
+    }
+
+    _dirtyComponents.clear();
+    render();
+  }
+
+  void render() {
+    buffer.render();
+  }
+}

--- a/lib/renderer/render_manager.dart
+++ b/lib/renderer/render_manager.dart
@@ -1,5 +1,5 @@
 import 'package:pixel_prompt/core/canvas_buffer.dart';
-import 'package:pixel_prompt/core/components.dart';
+import 'package:pixel_prompt/core/component.dart';
 
 class RenderManager {
   final CanvasBuffer buffer;

--- a/test/components/text_component_style.dart
+++ b/test/components/text_component_style.dart
@@ -1,0 +1,22 @@
+import 'package:pixel_prompt/components/colors.dart';
+import 'package:pixel_prompt/components/text_component_style.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group("Text component style string tests", () {
+    test(
+      "Style code for expected composable styles should return expected corresponding ANSI code",
+      () {
+        final style = TextComponentStyle()
+            .foreground(Colors.red)
+            .background(Colors.white)
+            .bold();
+
+        final expectedAnsiString = "31;47;1";
+        final actualAnsiString = style.getStyleAnsi();
+
+        expect(expectedAnsiString == actualAnsiString, isTrue);
+      },
+    );
+  });
+}

--- a/test/core/buffer_cell_test.dart
+++ b/test/core/buffer_cell_test.dart
@@ -1,0 +1,41 @@
+import 'package:pixel_prompt/components/colors.dart';
+import 'package:pixel_prompt/components/font_style.dart';
+import 'package:pixel_prompt/core/buffer_cell.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BufferCell equality', () {
+    test('Should be equal when all fields match', () {
+      final cell1 = BufferCell(
+        char: 'A',
+        fg: Colors.red,
+        bg: ColorRGB(0, 0, 0),
+        styles: {FontStyle.bold},
+      );
+      final cell2 = BufferCell(
+        char: 'A',
+        fg: Colors.red,
+        bg: ColorRGB(0, 0, 0),
+        styles: {FontStyle.bold},
+      );
+      expect(cell1 == cell2, isTrue);
+    });
+
+    test('Should not be equal when one or more field differs', () {
+      final cell1 = BufferCell(
+        char: 'A',
+        fg: Colors.red,
+        bg: ColorRGB(0, 0, 0),
+        styles: {FontStyle.bold},
+      );
+      final cell2 = BufferCell(
+        char: 'A',
+        fg: Colors.red,
+        bg: ColorRGB(0, 0, 0),
+        styles: {FontStyle.italic},
+      );
+
+      expect(cell1 == cell2, isFalse);
+    });
+  });
+}

--- a/test/core/canvas_buffer_test.dart
+++ b/test/core/canvas_buffer_test.dart
@@ -1,0 +1,202 @@
+import 'package:pixel_prompt/components/colors.dart';
+import 'package:pixel_prompt/components/text_component.dart';
+import 'package:pixel_prompt/components/text_component_style.dart';
+import 'package:pixel_prompt/core/buffer_cell.dart';
+import 'package:pixel_prompt/core/canvas_buffer.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/core/size.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Canvas Buffer', () {
+    final List<List<BufferCell>> expectedBuffer = [
+      [BufferCell(char: 'H'), BufferCell(char: 'e'), BufferCell(char: 'y')],
+      [BufferCell(char: 'T'), BufferCell(char: 'h'), BufferCell(char: 'e')],
+    ];
+
+    final List<String> expectedRenderedBuff = [
+      '\x1B[0mHey\x1B[0m',
+      '\x1B[0mThe\x1B[0m',
+    ];
+
+    test(
+      'After creating and writing on canvas using draw at the buffer should match the expected buffer',
+      () {
+        final CanvasBuffer canvasBuffer = CanvasBuffer(width: 3, height: 2);
+        canvasBuffer.drawAt(0, 0, 'Hey', TextComponentStyle());
+        canvasBuffer.drawAt(0, 1, 'The', TextComponentStyle());
+
+        expect(canvasBuffer.getRenderedString(), expectedRenderedBuff);
+        expect(canvasBuffer.getDrawnCanvas(), expectedBuffer);
+      },
+    );
+  });
+
+  test(
+    'Some with styling and others with different styling should render the expected output',
+    () {
+      final CanvasBuffer canvasBuffer = CanvasBuffer(width: 3, height: 2);
+      canvasBuffer.drawAt(
+        0,
+        0,
+        'He',
+        TextComponentStyle()
+            .foreground(ColorRGB(200, 12, 10))
+            .background(Colors.white),
+      );
+
+      canvasBuffer.drawAt(
+        2,
+        0,
+        'y',
+        TextComponentStyle()
+            .foreground(ColorRGB(2, 12, 10))
+            .background(Colors.highBlack),
+      );
+
+      canvasBuffer.drawAt(
+        0,
+        1,
+        'The',
+        TextComponentStyle().foreground(Colors.blue),
+      );
+
+      final expectedStringBuffer = [
+        "\x1B[0;38;2;200;12;10;47mHe\x1B[0;38;2;2;12;10;100my\x1B[0m",
+        "\x1B[0;34mThe\x1B[0m",
+      ];
+
+      expect(canvasBuffer.getRenderedString(), expectedStringBuffer);
+    },
+  );
+
+  test('Extra empty space should not interupt the render string', () {
+    final CanvasBuffer canvasBuffer = CanvasBuffer(width: 5, height: 3);
+    canvasBuffer.drawAt(
+      0,
+      0,
+      'He',
+      TextComponentStyle()
+          .foreground(ColorRGB(200, 12, 10))
+          .background(Colors.white),
+    );
+
+    canvasBuffer.drawAt(
+      2,
+      0,
+      'y',
+      TextComponentStyle()
+          .foreground(ColorRGB(2, 12, 10))
+          .background(Colors.highBlack),
+    );
+
+    canvasBuffer.drawAt(
+      0,
+      1,
+      'There',
+      TextComponentStyle().foreground(Colors.blue).background(Colors.black),
+    );
+
+    final expectedStringBuffer = [
+      "\x1B[0;38;2;200;12;10;47mHe\x1B[0;38;2;2;12;10;100my\x1B[0m  \x1B[0m",
+      "\x1B[0;34;40mThere\x1B[0m",
+      "\x1B[0m     \x1B[0m",
+    ];
+
+    expect(canvasBuffer.getRenderedString(), expectedStringBuffer);
+  });
+
+  test('Two text components with full padding can render next to each other', () {
+    final CanvasBuffer canvasBuffer = CanvasBuffer(width: 20, height: 20);
+    final TextComponent firstText = TextComponent(
+      "Fire",
+      style: TextComponentStyle()
+          .foreground(ColorRGB(255, 255, 255))
+          .background(ColorRGB(255, 68, 34))
+          .paddingTop(2)
+          .paddingBottom(2)
+          .paddingLeft(2)
+          .paddingRight(2),
+    );
+
+    final TextComponent secondText = TextComponent(
+      "Water",
+      style: TextComponentStyle()
+          .foreground(ColorRGB(255, 255, 255))
+          .background(ColorRGB(51, 153, 255))
+          .paddingTop(3)
+          .paddingBottom(3)
+          .paddingLeft(3)
+          .paddingRight(3),
+    );
+
+    final TextComponent thirdText = TextComponent(
+      "Ice",
+      style: TextComponentStyle()
+          .foreground(ColorRGB(255, 255, 255))
+          .background(ColorRGB(102, 204, 255))
+          .paddingTop(1)
+          .paddingBottom(1)
+          .paddingLeft(1)
+          .paddingRight(1),
+    );
+    final firstSize = firstText.measure(Size(width: 20, height: 20));
+    final secondSize = secondText.measure(
+      Size(width: 20 - firstSize.width, height: 20),
+    );
+    final thirdSize = firstText.measure(
+      Size(width: 20, height: 20 - secondSize.height),
+    );
+
+    final firstBounds = Rect(
+      x: 0,
+      y: 0,
+      width: firstSize.width,
+      height: firstSize.height,
+    );
+    final secondBounds = Rect(
+      x: firstBounds.x + firstBounds.width,
+      y: 0,
+      height: secondSize.height,
+      width: secondSize.width,
+    );
+    final thirdBound = Rect(
+      x: 0,
+      y: firstBounds.x + firstBounds.height,
+      width: thirdSize.width,
+      height: thirdSize.height,
+    );
+
+    firstText.render(canvasBuffer, firstBounds);
+    secondText.render(canvasBuffer, secondBounds);
+    thirdText.render(canvasBuffer, thirdBound);
+    final emptySpace = " " * 20;
+    final emptyStyle = "\x1B[0m$emptySpace\x1B[0m";
+
+    final rendered = canvasBuffer.getRenderedString();
+    final expected = [
+      "\x1B[0;38;2;255;255;255;48;2;255;68;34m        \x1B[0;38;2;255;255;255;48;2;51;153;255m           \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;255;68;34m        \x1B[0;38;2;255;255;255;48;2;51;153;255m           \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;255;68;34m  Fire  \x1B[0;38;2;255;255;255;48;2;51;153;255m           \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;255;68;34m        \x1B[0;38;2;255;255;255;48;2;51;153;255m   Water   \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;255;68;34m        \x1B[0;38;2;255;255;255;48;2;51;153;255m           \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;102;204;255m     \x1B[0m   \x1B[0;38;2;255;255;255;48;2;51;153;255m           \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;102;204;255m Ice \x1B[0m   \x1B[0;38;2;255;255;255;48;2;51;153;255m           \x1B[0m \x1B[0m",
+      "\x1B[0;38;2;255;255;255;48;2;102;204;255m     \x1B[0m               \x1B[0m",
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+      emptyStyle,
+    ];
+
+    expect(rendered, expected);
+  });
+}

--- a/test/layout_engine/layout_engine_test.dart
+++ b/test/layout_engine/layout_engine_test.dart
@@ -1,0 +1,41 @@
+import 'package:pixel_prompt/components/text_component.dart';
+import 'package:pixel_prompt/components/text_component_style.dart';
+import 'package:pixel_prompt/core/axis.dart';
+import 'package:pixel_prompt/core/component.dart';
+import 'package:pixel_prompt/core/rect.dart';
+import 'package:pixel_prompt/layout_engine/layout_engine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('initial width and height fitting pre size requirements', () {
+    test('calculated width and expected width should match', () {
+      final firstText = "hello world!";
+      final secondText = "what is your name";
+
+      final List<Component> children = [
+        TextComponent(firstText, style: TextComponentStyle()),
+        TextComponent(secondText, style: TextComponentStyle()),
+      ];
+      final direction = Axis.horizontal;
+      final bounds = Rect(
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+      ); // arbitrary number of width and height;
+      final engine = LayoutEngine(
+        children: children,
+        direction: direction,
+        bounds: bounds,
+      );
+      final expectedWidth = firstText.length + secondText.length + 1;
+      final actualWidth = engine.fitWidth();
+
+      final expectedHeight = 1;
+      final actualHeight = engine.fitHeight();
+
+      expect(expectedWidth, actualWidth);
+      expect(expectedHeight, actualHeight);
+    });
+  });
+}

--- a/test/pixel_prompt_test.dart
+++ b/test/pixel_prompt_test.dart
@@ -1,8 +1,0 @@
-import 'package:pixel_prompt/pixel_prompt.dart';
-import 'package:test/test.dart';
-
-void main() {
-  test('greet', () {
-    expect(greet(), "Welcome to pixel prompt!");
-  });
-}


### PR DESCRIPTION
### Added
- `LayoutEngine` to compute positions for child components based on direction and available space.
- `PositionedComponent` to associate layout bounds with renderable components.
- `Row` and `Column` components for horizontal and vertical composition.
- Unit tests for `LayoutEngine` covering relative positioning and edge cases.

### Notes
- `fitWidth` and `fitHeight` left unimplemented pending dynamic sizing logic.
- Absolute-positioned children are currently ignored by the layout engine.
