### PR TITLE
feat(input): introduce input management and focus handling

### DIFF
--- a/lib/common/response_input.dart
+++ b/lib/common/response_input.dart
@@ -1,0 +1,15 @@
+import 'package:pixel_prompt/core/component.dart';
+
+enum ResponseCommands { none, exit }
+
+class ResponseInput {
+  final ResponseCommands commands;
+  final bool handled;
+  final List<Component>? dirty;
+
+  const ResponseInput({
+    required this.commands,
+    required this.handled,
+    this.dirty,
+  });
+}

--- a/lib/core/interactable_component.dart
+++ b/lib/core/interactable_component.dart
@@ -1,0 +1,38 @@
+import 'package:pixel_prompt/core/component.dart';
+
+abstract class InteractableComponent extends Component {
+  bool isFocused = false;
+  bool isHovered = false;
+
+  void blur() {
+    isFocused = false;
+    onBlur();
+
+    return;
+  }
+
+  void focus() {
+    isFocused = true;
+    onFocus();
+
+    return;
+  }
+
+  void hover() {
+    isHovered = true;
+    onHover();
+
+    return;
+  }
+
+  void unhover() {
+    isHovered = false;
+    return;
+  }
+
+  void onFocus();
+  void onBlur();
+  void onHover();
+
+  void handleInput(String input);
+}

--- a/lib/handler/input_handler.dart
+++ b/lib/handler/input_handler.dart
@@ -1,0 +1,6 @@
+import 'package:pixel_prompt/events/input_event.dart';
+import 'package:pixel_prompt/common/response_input.dart';
+
+abstract class InputHandler {
+  ResponseInput handleInput(InputEvent event);
+}

--- a/lib/manager/command_mode_handler.dart
+++ b/lib/manager/command_mode_handler.dart
@@ -1,0 +1,62 @@
+import 'package:pixel_prompt/handler/input_handler.dart';
+import 'package:pixel_prompt/events/input_event.dart';
+import 'package:pixel_prompt/common/response_input.dart';
+
+class CommandModeHandler implements InputHandler {
+  bool _inCommandMode = false;
+  final StringBuffer _buffer = StringBuffer();
+
+  @override
+  ResponseInput handleInput(InputEvent event) {
+    if (!_shouldHandle(event)) {
+      return ResponseInput(commands: ResponseCommands.none, handled: true);
+    }
+
+    event = event as CharEvent;
+    if (event.char == '\r' || event.char == '\n') {
+      return executeCommand();
+    } else if (event.char == '\b' || event.char == '\x7F') {
+      String value = _buffer.toString();
+      if (value.isNotEmpty) {
+        value = value.substring(0, value.length - 1);
+        _buffer.clear();
+        _buffer.write(value);
+      }
+    } else {
+      _buffer.write(event.char);
+    }
+
+    return ResponseInput(commands: ResponseCommands.none, handled: true);
+  }
+
+  ResponseInput executeCommand() {
+    final ResponseCommands responseCommands;
+    if (_buffer.toString() == ':q') {
+      responseCommands = ResponseCommands.exit;
+    } else {
+      responseCommands = ResponseCommands.none;
+    }
+
+    _exitCommandMode();
+    return ResponseInput(commands: responseCommands, handled: true);
+  }
+
+  bool _shouldHandle(InputEvent event) {
+    if (!_inCommandMode && event is CharEvent && event.char == ':') {
+      _enterCommandMode();
+    }
+    return _inCommandMode ||
+        (!_inCommandMode && event is CharEvent && event.char == ':');
+  }
+
+  void _enterCommandMode() {
+    _inCommandMode = true;
+    _buffer.clear();
+    _buffer.write(':');
+  }
+
+  void _exitCommandMode() {
+    _inCommandMode = false;
+    _buffer.clear();
+  }
+}

--- a/lib/manager/focus_manager.dart
+++ b/lib/manager/focus_manager.dart
@@ -1,0 +1,122 @@
+import 'package:pixel_prompt/handler/input_handler.dart';
+import 'package:pixel_prompt/core/context.dart';
+import 'package:pixel_prompt/core/interactable_component.dart';
+import 'package:pixel_prompt/events/input_event.dart';
+import 'package:pixel_prompt/common/response_input.dart';
+
+class FocusManager implements InputHandler {
+  final Context context;
+
+  final List<InteractableComponent> components = [];
+  InteractableComponent? _currentComponent;
+  InteractableComponent? _hoveredComponent;
+  int currentIndex = -1;
+
+  FocusManager({required this.context});
+
+  void register(InteractableComponent c) {
+    components.add(c);
+  }
+
+  ResponseInput handleTab(bool shiftPressed) {
+    if (components.isEmpty) {
+      return ResponseInput(commands: ResponseCommands.none, handled: false);
+    }
+
+    if (currentIndex == -1) {
+      currentIndex = shiftPressed ? components.length - 1 : 0;
+      components[currentIndex].focus();
+      _currentComponent = components[currentIndex];
+
+      return ResponseInput(
+        commands: ResponseCommands.none,
+        handled: true,
+        dirty: [_currentComponent!],
+      );
+    }
+
+    final List<InteractableComponent> dirtyComponents = [];
+
+    _currentComponent!.blur();
+    dirtyComponents.add(components[currentIndex]);
+
+    if (shiftPressed) {
+      currentIndex = (currentIndex - 1 + components.length) % components.length;
+    } else {
+      currentIndex = (currentIndex + 1) % components.length;
+    }
+    _currentComponent = components[currentIndex];
+    _currentComponent!.focus();
+    dirtyComponents.add(_currentComponent!);
+
+    return ResponseInput(
+      commands: ResponseCommands.none,
+      handled: true,
+      dirty: dirtyComponents,
+    );
+  }
+
+  @override
+  ResponseInput handleInput(InputEvent event) {
+    if (event is ShiftTabEvent) {
+      return handleTab(true);
+    } else if (event is TabEvent) {
+      return handleTab(false);
+    } else if (event is MouseEvent) {
+      final List<InteractableComponent> dirtyComponents = [];
+
+      InteractableComponent? hoveredNow;
+
+      for (int i = 0; i < components.length; i++) {
+        final component = components[i];
+        if (_isWithinBounds(event.x, event.y, component)) {
+          hoveredNow = component;
+
+          if (event.type == MouseEventType.release) {
+            component.hover();
+            dirtyComponents.add(component);
+          } else if (event.type == MouseEventType.click) {
+            _currentComponent?.blur();
+            component.focus();
+
+            if (_currentComponent != null) {
+              dirtyComponents.add(_currentComponent!);
+            }
+            dirtyComponents.add(component);
+
+            _currentComponent = component;
+          }
+          break;
+        }
+      }
+
+      if (_hoveredComponent != hoveredNow) {
+        if (_hoveredComponent != null) {
+          _hoveredComponent!.unhover();
+          dirtyComponents.add(_hoveredComponent!);
+        }
+        _hoveredComponent = hoveredNow;
+      }
+
+      return ResponseInput(
+        commands: ResponseCommands.none,
+        handled: true,
+        dirty: dirtyComponents,
+      );
+    }
+    return ResponseInput(commands: ResponseCommands.none, handled: false);
+  }
+
+  bool _isWithinBounds(int x, int y, InteractableComponent component) {
+    final bounds = component.getBounds();
+
+    final adjustedX = bounds.x + context.cursorX;
+    final adjustedY = bounds.y + context.cursorY;
+
+    final graceWidth = adjustedX + bounds.width + 5;
+    final graceHeight = adjustedY + bounds.height;
+
+    return (x >= adjustedX && x < graceWidth) &&
+        (y >= adjustedY && y < graceHeight);
+  }
+}

--- a/lib/manager/input_dispatcher.dart
+++ b/lib/manager/input_dispatcher.dart
@@ -1,0 +1,38 @@
+import 'package:pixel_prompt/handler/input_handler.dart';
+import 'package:pixel_prompt/events/input_event.dart';
+import 'package:pixel_prompt/common/response_input.dart';
+import 'package:pixel_prompt/renderer/render_manager.dart';
+
+class InputDispatcher {
+  final RenderManager _renderManager;
+  final List<InputHandler> _handlers = [];
+
+  InputDispatcher({required RenderManager renderer})
+    : _renderManager = renderer;
+
+  void registerHandler(InputHandler handler) {
+    if (!_handlers.contains(handler)) {
+      _handlers.add(handler);
+    }
+  }
+
+  void unregisterHandler(InputHandler handler) {
+    _handlers.remove(handler);
+  }
+
+  bool dispatchEvent(InputEvent event) {
+    for (var handler in _handlers) {
+      final response = handler.handleInput(event);
+      if (response.handled) {
+        for (final component in response.dirty ?? []) {
+          _renderManager.markDirty(component);
+        }
+
+        if ((response.dirty ?? []).isNotEmpty) _renderManager.requestRedraw();
+        if (response.commands == ResponseCommands.exit) return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/lib/manager/input_manager.dart
+++ b/lib/manager/input_manager.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+import 'package:pixel_prompt/events/input_event.dart';
+import 'package:pixel_prompt/manager/input_dispatcher.dart';
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+class InputManager {
+  bool _isInputPaused = false;
+  bool _expectingCursorResponse = false;
+
+  void Function(int, int)? _cursorCallback;
+
+  Function(MouseEvent)? onEvent;
+
+  StreamSubscription<List<int>>? _stdinSubscription;
+
+  final InputDispatcher _dispatcher;
+  final List<int> _inputBuffer = [];
+  final List<int> _cursorInputBuffer = [];
+
+  InputManager({required InputDispatcher dispatcher})
+    : _dispatcher = dispatcher {
+    _configureStdin();
+    _enableMouseInput();
+
+    if (Platform.isWindows) {
+      _enableWindowsAnsi();
+    }
+
+    _stdinSubscription = stdin.listen(_manageHandlers);
+  }
+
+  void _configureStdin() {
+    stdin
+      ..echoMode = false
+      ..lineMode = false;
+  }
+
+  void _enableMouseInput() {
+    stdout.write('\x1B[?1006h\x1B[?1003h');
+  }
+
+  void _enableWindowsAnsi() {
+    final handle = GetStdHandle(STD_INPUT_HANDLE);
+    var mode = calloc<DWORD>();
+
+    GetConsoleMode(handle, mode);
+    SetConsoleMode(
+      handle,
+      mode.value |
+          ENABLE_VIRTUAL_TERMINAL_INPUT |
+          ENABLE_MOUSE_INPUT |
+          ENABLE_WINDOW_INPUT,
+    );
+    calloc.free(mode);
+  }
+
+  void _restoreWindowsConsoleMode() {
+    final handle = GetStdHandle(STD_INPUT_HANDLE);
+    var mode = calloc<DWORD>();
+
+    GetConsoleMode(handle, mode);
+    SetConsoleMode(
+      handle,
+      mode.value &
+          ~(ENABLE_VIRTUAL_TERMINAL_INPUT |
+              ENABLE_MOUSE_INPUT |
+              ENABLE_WINDOW_INPUT),
+    );
+
+    calloc.free(mode);
+  }
+
+  void _manageHandlers(List<int> data) {
+    if (_isInputPaused) return;
+
+    if (_expectingCursorResponse) {
+      _handleCursorResponse(data);
+      return;
+    }
+
+    _inputBuffer.addAll(data);
+
+    while (_inputBuffer.isNotEmpty) {
+      InputEvent dispatchedEvent;
+
+      if (_inputBuffer.length >= 3 &&
+          _inputBuffer[0] == 0x1B &&
+          _inputBuffer[1] == 0x5B &&
+          _inputBuffer[2] == 0x3C) {
+        // 0x1B 0x5B 0x3C == /x1B[<
+        // EVENT IS MOUSE EVENT
+        final mouseEvents = _processMouseBuffer();
+        for (final event in mouseEvents) {
+          _dispatcher.dispatchEvent(event);
+        }
+        return;
+      } else if (_inputBuffer[0] == 0x1B && _inputBuffer.length >= 3) {
+        final List<int> sequence = _inputBuffer.sublist(0, 3);
+        // EVENT IS A NORMAL SPECIAL KEY EVENT
+
+        if (sequence[2] == 0x5A) {
+          dispatchedEvent = ShiftTabEvent();
+        } else {
+          dispatchedEvent = SequenceEvent(sequence: sequence);
+        }
+
+        _inputBuffer.removeRange(0, 3);
+      } else if (_inputBuffer[0] == 0xE0 && _inputBuffer.length >= 2) {
+        final sequence = _inputBuffer.sublist(0, 2);
+        if (sequence[1] == 0x5A) {
+          dispatchedEvent = ShiftTabEvent();
+        } else {
+          dispatchedEvent = SequenceEvent(sequence: sequence);
+        }
+
+        _inputBuffer.removeRange(0, 2);
+      } else if (_inputBuffer.length == 1) {
+        final byte = _inputBuffer.removeAt(0);
+        final input = String.fromCharCode(byte);
+        // EVENT IS A NORMAL KEY for any device
+        if (input == '\t') {
+          dispatchedEvent = TabEvent();
+        } else if (byte >= 32 && byte <= 126) {
+          dispatchedEvent = CharEvent(char: input);
+        } else {
+          dispatchedEvent = UnknownEvent(byte: byte);
+        }
+      } else {
+        // UNKNOWN INPUT EVENT
+        dispatchedEvent = UnknownEvent();
+      }
+
+      if (_dispatcher.dispatchEvent(dispatchedEvent)) stop();
+    }
+  }
+
+  void _handleCursorResponse(List<int> data) {
+    _cursorInputBuffer.addAll(data);
+
+    String input = String.fromCharCodes(_cursorInputBuffer);
+
+    RegExp regex = RegExp(r'\x1B\[(\d+);(\d+)R');
+    Match? match = regex.firstMatch(input);
+
+    if (match != null) {
+      _expectingCursorResponse = false;
+      _cursorInputBuffer.clear();
+
+      int row = int.parse(match.group(1)!);
+      int col = int.parse(match.group(2)!);
+      _cursorCallback?.call(col - 1, row - 1);
+    }
+
+    return;
+  }
+
+  void stop() {
+    stdout.write('\x1B[?1006l\x1B[?1003l');
+
+    if (Platform.isWindows) {
+      _restoreWindowsConsoleMode();
+    } else {
+      stdin
+        ..echoMode = true
+        ..lineMode = true;
+    }
+    stdout.write(
+      '\x1B[?1049l',
+    ); // TODO: make sure ONLY to handle this in full screen mode
+    _stdinSubscription?.cancel();
+  }
+
+  void pauseInput() {
+    _isInputPaused = true;
+  }
+
+  void resumeInput() {
+    _isInputPaused = false;
+  }
+
+  List<MouseEvent> _processMouseBuffer() {
+    final List<MouseEvent> mouseEvents = [];
+    while (true) {
+      int start = _inputBuffer.indexOf(27);
+      if (start == -1) break;
+
+      int end = _inputBuffer.indexOf(77, start);
+      if (end == -1) {
+        end = _inputBuffer.indexOf(109, start);
+        if (end == -1) break;
+      }
+
+      String sequence = String.fromCharCodes(
+        _inputBuffer.sublist(start, end + 1),
+      );
+      _inputBuffer.removeRange(start, end + 1);
+      final event = _parseMouseEvent(sequence);
+      if (event != null) mouseEvents.add(event);
+    }
+
+    return mouseEvents;
+  }
+
+  void getCursorPosition(void Function(int x, int y) callback) {
+    stdout.write('\x1B[6n');
+    _expectingCursorResponse = true;
+    _cursorCallback = callback;
+  }
+
+  MouseEvent? _parseMouseEvent(String sequence) {
+    try {
+      String data = sequence.substring(3, sequence.length - 1);
+      List<String> parts = data.split(';');
+      if (parts.length != 3) return null;
+
+      int cb = int.parse(parts[0]);
+      int x = int.parse(parts[1]) - 1;
+      int y = int.parse(parts[2]) - 1;
+      bool isRelease = sequence.endsWith('m');
+      bool isMotion = (cb & 0x20) != 0;
+
+      MouseEventType type = MouseEventType.click;
+      if (isRelease) {
+        type = MouseEventType.release;
+      } else if (isMotion) {
+        type = MouseEventType.hover;
+      }
+
+      int button = cb & ~0x20;
+
+      return MouseEvent(type: type, x: x, y: y, button: button);
+    } catch (e) {
+      print('Error parsing mouse event: $e');
+      return null;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ repository: https://github.com/primequantuM4/pixel_prompt
 issue_tracker: https://github.com/primequantuM4/pixel_prompt/issues
 
 dependencies:
+  ffi: ^2.1.4
+  win32: ^5.14.0
   # path: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
### Added
- `InputManager` to receive raw input and distribute to the correct component.
- `InputDispatcher` for separating routing logic from handling logic.
- `FocusManager` for tracking the currently focused component.
- `CommandModeHandler` for handling any terminal control related commands.
- `ResponseInput` for wrapping and normalizing input state (e.g. character input, key modifiers).
- Added package `ffi` and `win32` for windows input handling.
- Initial support for focusable components.

### Notes
- This sets the foundation for interactive components like `TextField` and `Checkbox`.
- No user-facing components added in this PR — this focuses on infrastructure only.
