### PR TITLE
docs: add Dartdoc comments to core framework classes

### DIFF
--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -19,15 +19,35 @@ import 'package:pixel_prompt/manager/input_manager.dart';
 import 'package:pixel_prompt/renderer/render_manager.dart';
 import 'package:pixel_prompt/terminal/terminal_functions.dart';
 
+/// The root component of a PixelPrompt terminal UI application.
+///
+/// [App] is the top-level component that contains and lays out all children,
+/// and is responsible for initializing the terminal environment, layout,
+/// rendering, and input event handling.
+///
+/// It lays out its children using the provided [direction] (horizontal or vertical),
+/// and acts as a container implementing [ParentComponent].
+///
+/// The [run] extension method initializes the terminal screen, builds the layout,
+/// configures focus and input handlers, and renders the first frame.
 class App extends Component with ParentComponent {
+  /// The list of components that make up the UI.
   @override
   final List<Component> children;
+
+  /// The layout direction for arranging [children] — vertical or horizontal.
   final Axis direction;
 
   static const String _tag = 'App';
 
+  /// Constructs an [App] with the given [children] and layout [direction].
   App({required this.children, this.direction = Axis.vertical});
 
+  /// Measures the total size needed to render the app based on [maxSize].
+  ///
+  /// Components with `PositionType.absolute` are ignored in layout measurement.
+  /// Returns the combined height (or width) and max child width (or height),
+  /// depending on the layout [direction].
   @override
   Size measure(Size maxSize) {
     int totalHeight = 0;
@@ -45,6 +65,10 @@ class App extends Component with ParentComponent {
     return Size(width: maxWidth, height: totalHeight);
   }
 
+  /// Renders all children into the given [buffer] using layout bounds [bounds].
+  ///
+  /// Delegates layout to [LayoutEngine] and recursively renders all children
+  /// in computed positions.
   @override
   void render(CanvasBuffer buffer, Rect bounds) {
     final LayoutEngine engine = LayoutEngine(
@@ -61,12 +85,18 @@ class App extends Component with ParentComponent {
     }
   }
 
+  /// Reserved for future use with dynamic height layout.
+  ///
+  /// Not yet implemented.
   @override
   int fitHeight() {
     // TODO: Implement once dynamic sizing (flex/grow/shrink) is supported
     throw UnimplementedError();
   }
 
+  /// Reserved for future use with dynamic width layout.
+  ///
+  /// Not yet implemented.
   @override
   int fitWidth() {
     // TODO: Implement once dynamic sizing (flex/grow/shrink) is supported
@@ -74,7 +104,31 @@ class App extends Component with ParentComponent {
   }
 }
 
+/// Extension that runs the TUI application by bootstrapping all core managers.
+///
+/// The [run] method initializes:
+/// - Terminal size
+/// - Canvas rendering
+/// - Input handling
+/// - Focus and interactivity
+///
+/// It is the main entry point for any terminal UI application built with
+/// the PixelPrompt framework.
+///
+/// Example usage:
+/// ```dart
+/// void main() {
+///   final app = App(children: [...]);
+///   app.run();
+/// }
+/// ```
 extension AppRunner on App {
+  /// Initializes and runs the app.
+  ///
+  /// 1. Reads terminal size using [TerminalFunctions].
+  /// 2. Creates a [CanvasBuffer] for rendering.
+  /// 3. Initializes input handling, focus, and interactivity.
+  /// 4. Measures layout and renders the component tree.
   void run() async {
     final rawTerminalWidth =
         TerminalFunctions.hasTerminal ? TerminalFunctions.terminalWidth : 80;

--- a/lib/core/buffer_cell.dart
+++ b/lib/core/buffer_cell.dart
@@ -1,15 +1,56 @@
 import 'package:pixel_prompt/components/colors.dart';
 import 'package:pixel_prompt/components/font_style.dart';
 
+/// A single character cell in the terminal UI buffer.
+///
+/// Each [BufferCell] represents one printable cell on the terminal grid,
+/// holding a character, foreground/background color, and font styling.
+/// This is the fundamental unit used by the rendering engine to track
+/// visual content.
+///
+/// The cell is mutable and can be cleared or compared to others
+/// for optimized redraws or diffing purposes.
 class BufferCell {
+  /// The character rendered in the cell.
+  ///
+  /// **Must** be a single character string.
   String char;
+
+  /// The optional foreground color of the cell.
   AnsiColorType? fg;
+
+  /// The optional background color of the cell.
   AnsiColorType? bg;
+
+  /// A set of font styles (e.g., bold, italic) applied to this cell.
   Set<FontStyle> styles;
 
-  BufferCell({required this.char, this.fg, this.bg, Set<FontStyle>? styles})
-    : styles = styles ?? {};
+  /// Creates a [BufferCell] with the given [char], optional [fg], [bg],
+  /// and a set of [styles].
+  ///
+  /// If [styles] is not provided, it defaults to an empty set.
+  BufferCell({
+    required this.char,
+    this.fg,
+    this.bg,
+    Set<FontStyle>? styles,
+  }) : styles = styles ?? {};
 
+  /// Clears the contents of this cell.
+  ///
+  /// Resets [char] to a space `' '`, removes any foreground/background color,
+  /// and clears all font styles.
+  void clear() {
+    char = ' ';
+    fg = null;
+    bg = null;
+    styles.clear();
+  }
+
+  /// Compares this cell to [other] for value equality.
+  ///
+  /// Two cells are equal if their character, foreground, background,
+  /// and styles match.
   @override
   bool operator ==(Object other) {
     return other is BufferCell &&
@@ -19,17 +60,12 @@ class BufferCell {
             _setEquals(other.styles, styles));
   }
 
-  void clear() {
-    char = ' ';
-    fg = null;
-    bg = null;
-    styles.clear();
-  }
-
+  /// Returns a hash code based on the character, colors, and styles.
   @override
   int get hashCode =>
       Object.hash(char, fg, bg, Object.hashAllUnordered(styles));
 
+  /// Compares two sets for unordered equality.
   bool _setEquals(Set a, Set b) {
     return a.length == b.length && a.containsAll(b);
   }

--- a/lib/core/component.dart
+++ b/lib/core/component.dart
@@ -12,7 +12,7 @@ import 'package:pixel_prompt/core/size.dart';
 /// buttons, etc.
 ///
 /// Each component may be optionally positioned using a [Position].
-/// The layout engine is responsible for calling [setBounds] during layout
+/// The layout engine is responsible for calling [bounds] during layout
 /// computation, which must happen before [render] is called.
 ///
 /// Subclasses must implement:
@@ -36,7 +36,7 @@ abstract class Component {
   /// Sets the computed bounding rectangle of this component.
   ///
   /// Called by the layout engine during layout phase.
-  set setBounds(Rect bounds) => _bounds = bounds;
+  set bounds(Rect bounds) => _bounds = bounds;
 
   /// Creates a component with an optional [position].
   Component({this.position});

--- a/lib/core/component.dart
+++ b/lib/core/component.dart
@@ -25,17 +25,16 @@ abstract class Component {
 
   Rect? _bounds;
 
-  /// Returns the bounding rectangle of the component.
+  /// The bounding rectangle of the component.
   ///
-  /// Throws an [Exception] if the bounds have not yet been set.
+  /// This is set by the layout engine during layout, and is required
+  /// before rendering. Accessing [bounds] before it is set will throw
+  /// an [Exception]
   Rect get bounds {
     if (_bounds == null) throw Exception("Component bounds not set yet");
     return _bounds!;
   }
 
-  /// Sets the computed bounding rectangle of this component.
-  ///
-  /// Called by the layout engine during layout phase.
   set bounds(Rect bounds) => _bounds = bounds;
 
   /// Creates a component with an optional [position].

--- a/lib/core/component.dart
+++ b/lib/core/component.dart
@@ -3,28 +3,69 @@ import 'package:pixel_prompt/core/position.dart';
 import 'package:pixel_prompt/core/rect.dart';
 import 'package:pixel_prompt/core/size.dart';
 
+/// The base class for all renderable UI components in the framework.
+///
+/// A [Component] defines the minimal contract for a terminal UI element,
+/// including layout sizing, positioning, and rendering.
+///
+/// It is intended to be subclassed by concrete widgets such as boxes, text,
+/// buttons, etc.
+///
+/// Each component may be optionally positioned using a [Position].
+/// The layout engine is responsible for calling [setBounds] during layout
+/// computation, which must happen before [render] is called.
+///
+/// Subclasses must implement:
+/// - [measure] to report their preferred size given a constraint,
+/// - [fitWidth] and [fitHeight] to determine growth behavior in layout,
+/// - [render] to draw themselves into a [CanvasBuffer].
 abstract class Component {
+  /// Optional position specifier.
   final Position? position;
 
   Rect? _bounds;
 
-  void setBounds(Rect bounds) {
-    _bounds = bounds;
-  }
-
-  Rect getBounds() {
+  /// Returns the bounding rectangle of the component.
+  ///
+  /// Throws an [Exception] if the bounds have not yet been set.
+  Rect get bounds {
     if (_bounds == null) throw Exception("Component bounds not set yet");
     return _bounds!;
   }
 
+  /// Sets the computed bounding rectangle of this component.
+  ///
+  /// Called by the layout engine during layout phase.
+  set setBounds(Rect bounds) => _bounds = bounds;
+
+  /// Creates a component with an optional [position].
   Component({this.position});
 
+  /// Measures the component’s preferred size given a [maxSize] constraint.
+  ///
+  /// This is used by the layout system to determine how much space the
+  /// component would like to occupy.
   Size measure(Size maxSize);
+
+  /// Returns the minimum width this component needs to be laid out.
   int fitWidth();
+
+  /// Returns the minimum height this component needs to be laid out.
   int fitHeight();
+
+  /// Renders this component into the [buffer] using the given [bounds].
+  ///
+  /// Called during the paint phase after layout is complete.
   void render(CanvasBuffer buffer, Rect bounds);
 }
 
+/// A mixin for components that act as containers for child components.
+///
+/// Classes mixing in [ParentComponent] must expose a list of [children]
+/// which the layout system will recursively measure, layout, and render.
+///
+/// This is used by layout containers like `Column`, `Row`, or custom panels
+/// that nest multiple child components.
 mixin ParentComponent on Component {
   List<Component> get children;
 }

--- a/lib/core/context.dart
+++ b/lib/core/context.dart
@@ -1,3 +1,4 @@
+//TODO: Generate DocString once context becomes more involved
 class Context {
   int cursorX = -1;
   int cursorY = -1;

--- a/lib/core/interactable_component.dart
+++ b/lib/core/interactable_component.dart
@@ -3,21 +3,69 @@ import 'package:pixel_prompt/core/component.dart';
 import 'package:pixel_prompt/events/input_event.dart';
 import 'package:pixel_prompt/renderer/render_manager.dart';
 
+/// A base class for components that support interaction, focus, hover, and input.
+///
+/// [InteractableComponent] defines the lifecycle for UI elements that can receive
+/// user input (e.g., keypresses, mouse events), be focused, hovered, and clicked.
+///
+/// Subclasses must implement the interaction lifecycle methods:
+/// - [onFocus]
+/// - [onBlur]
+/// - [onHover]
+/// - [onClick]
+/// - [handleInput]
+///
+/// This class works in conjunction with the [RenderManager] to notify the system
+/// when the component needs to be redrawn via [markDirty].
+///
+/// It also exposes overridable flags for interactivity:
+/// - [isFocusable]: whether the component can be focused
+/// - [isHoverable]: whether it can be hovered
+/// - [wantsInput]: whether it actively listens for input events
+///
+/// Components that extend this must be part of a widget tree managed by a
+/// [RenderManager] for state updates and re-rendering to function correctly.
 abstract class InteractableComponent extends Component {
+  /// The render manager responsible for repaint and state coordination.
+  ///
+  /// Must be assigned for [markDirty] to trigger UI updates.
   RenderManager? renderManager;
+
+  /// Whether this component is currently focused.
   bool isFocused = false;
+
+  /// Whether this component is currently being hovered.
   bool isHovered = false;
 
+  /// Whether this component can receive focus.
+  ///
+  /// Override to return `true` if the component should be focusable.
   bool get isFocusable => false;
+
+  /// Whether this component can be hovered.
+  ///
+  /// Override to return `true` if the component should respond to hover state.
   bool get isHoverable => false;
+
+  /// Whether this component wants to receive input events.
+  ///
+  /// Override to return `true` if the component handles input directly.
   bool get wantsInput => false;
 
+  /// Marks this component as dirty and schedules a redraw.
+  ///
+  /// This should be called when internal state changes and the component
+  /// needs to be re-rendered.
   void markDirty() {
     if (renderManager != null) {
       renderManager!.markDirty(this);
       renderManager!.requestRedraw();
     }
   }
+
+  /// Removes focus and hover state from this component.
+  ///
+  /// Triggers the [onBlur] lifecycle method.
 
   void blur() {
     isFocused = false;
@@ -27,6 +75,9 @@ abstract class InteractableComponent extends Component {
     return;
   }
 
+  /// Gives focus to this component.
+  ///
+  /// Triggers the [onFocus] lifecycle method.
   void focus() {
     isFocused = true;
     onFocus();
@@ -34,6 +85,9 @@ abstract class InteractableComponent extends Component {
     return;
   }
 
+  /// Marks this component as hovered.
+  ///
+  /// Triggers the [onHover] lifecycle method.
   void hover() {
     isHovered = true;
     onHover();
@@ -41,15 +95,26 @@ abstract class InteractableComponent extends Component {
     return;
   }
 
+  /// Removes hover state from this component.
   void unhover() {
     isHovered = false;
     return;
   }
 
+  /// Called when the component gains focus.
   void onFocus();
+
+  /// Called when the component loses focus.
   void onBlur();
+
+  /// Called when the component is hovered.
   void onHover();
+
+  /// Called when the component is clicked.
   void onClick();
 
+  /// Handles raw input events from the input system.
+  ///
+  /// Must return a [ResponseInput] to indicate whether the event was consumed.
   ResponseInput handleInput(InputEvent event);
 }

--- a/lib/core/interactable_registry.dart
+++ b/lib/core/interactable_registry.dart
@@ -3,6 +3,20 @@ import 'package:pixel_prompt/core/interactable_component.dart';
 import 'package:pixel_prompt/manager/focus_manager.dart';
 import 'package:pixel_prompt/renderer/render_manager.dart';
 
+/// A utility class for recursively registering interactable components.
+///
+/// [InteractableRegistry] walks the component tree and registers any
+/// [InteractableComponent] instances with the provided [FocusManager],
+/// and assigns the given [RenderManager] to them.
+///
+/// This is typically called once during the initialization of a UI scene
+/// to wire up interactivity and state-driven rendering.
+///
+/// Example usage:
+/// ```dart
+/// final registry = InteractableRegistry();
+/// registry.registerInteractables(rootComponent, focusManager, renderManager);
+/// ```
 class InteractableRegistry {
   void registerInteractables(
     Component component,
@@ -21,11 +35,3 @@ class InteractableRegistry {
     }
   }
 }
-
-
-// App
-    // Checkbox List
-        // checkbox
-        // checkbox
-        // checkbox
-

--- a/lib/core/position.dart
+++ b/lib/core/position.dart
@@ -1,8 +1,26 @@
+/// Represents a 2D position with a defined positioning mode.
+///
+/// A [Position] combines an [x] and [y] coordinate with a [PositionType]
+/// to specify whether the values are interpreted as absolute or relative
+/// within a layout or rendering context.
+///
+/// Used for positioning components or elements within containers or the screen.
 class Position {
+  /// The horizontal offset.
   final int x;
+
+  /// The vertical offset.
   final int y;
+
+  /// The type of positioning to apply (absolute or relative).
   final PositionType positionType;
 
+  /// Creates a [Position] with the given [x], [y], and [positionType].
+  ///
+  /// - If [positionType] is [PositionType.absolute], [x] and [y] are
+  ///   interpreted as fixed coordinates.
+  /// - If [positionType] is [PositionType.relative], they are interpreted
+  ///   relative to a parent or reference point.
   const Position({
     required this.x,
     required this.y,
@@ -11,4 +29,3 @@ class Position {
 }
 
 enum PositionType { absolute, relative }
-

--- a/lib/core/rect.dart
+++ b/lib/core/rect.dart
@@ -1,8 +1,28 @@
+/// A simple immutable rectangle defined by its top-left corner and size.
+///
+/// The [Rect] class represents a rectangular region in a 2D space using
+/// integer coordinates and dimensions. It is defined by:
+/// - the top-left corner ([x], [y])
+/// - the [width] and [height] of the rectangle
+///
+/// This class is typically used for layout, rendering bounds, or hit-testing
+/// in the terminal UI system.
 class Rect {
+  /// The horizontal coordinate of the top-left corner.
   final int x;
+
+  /// The vertical coordinate of the top-left corner.
   final int y;
+
+  /// The width of the rectangle.
   final int width;
+
+  /// The height of the rectangle.
   final int height;
+
+  /// Creates a [Rect] with the given [x], [y], [width], and [height].
+  ///
+  /// All parameters are required and must be non-null.
   const Rect({
     required this.x,
     required this.y,
@@ -10,9 +30,18 @@ class Rect {
     required this.height,
   });
 
+  /// The horizontal coordinate of the right edge of the rectangle.
+  ///
+  /// Equivalent to `x + width`.
   int get right => x + width;
+
+  /// The vertical coordinate of the bottom edge of the rectangle.
+  ///
+  /// Equivalent to `y + height`.
   int get bottom => y + height;
 
+  /// Returns a string representation of the rectangle, including its
+  /// position and size.
   @override
   String toString() => 'x:$x, y:$y, width:$width, height:$height';
 }

--- a/lib/core/size.dart
+++ b/lib/core/size.dart
@@ -1,6 +1,20 @@
+/// Represents the width and height dimensions of a rectangular area.
+///
+/// The [Size] class is used to describe the dimensions of components,
+/// containers, and layout regions within the terminal UI framework.
+///
+/// Both [width] and [height] are mutable to allow dynamic resizing.
 class Size {
+  /// The horizontal extent.
+
   int width;
+
+  /// The vertical extent.
+
   int height;
 
+  /// Creates a [Size] with the given [width] and [height].
+  ///
+  /// Both dimensions must be non-negative.
   Size({required this.width, required this.height});
 }

--- a/lib/layout_engine/layout_engine.dart
+++ b/lib/layout_engine/layout_engine.dart
@@ -40,7 +40,7 @@ class LayoutEngine {
           height: size.height,
         );
         result.add(PositionedComponent(component: child, rect: bounds));
-        child.setBounds = bounds;
+        child.bounds = bounds;
         continue;
       }
 
@@ -65,7 +65,7 @@ class LayoutEngine {
       }
 
       result.add(PositionedComponent(component: child, rect: childBounds));
-      child.setBounds = bounds;
+      child.bounds = bounds;
 
       if (direction == Axis.vertical) {
         cursorY += size.height + childGap;

--- a/lib/layout_engine/layout_engine.dart
+++ b/lib/layout_engine/layout_engine.dart
@@ -40,7 +40,7 @@ class LayoutEngine {
           height: size.height,
         );
         result.add(PositionedComponent(component: child, rect: bounds));
-        child.setBounds(bounds);
+        child.setBounds = bounds;
         continue;
       }
 
@@ -65,7 +65,7 @@ class LayoutEngine {
       }
 
       result.add(PositionedComponent(component: child, rect: childBounds));
-      child.setBounds(childBounds);
+      child.setBounds = bounds;
 
       if (direction == Axis.vertical) {
         cursorY += size.height + childGap;

--- a/lib/logger/logger.dart
+++ b/lib/logger/logger.dart
@@ -1,21 +1,56 @@
 import 'dart:io';
 
+/// A utility class for conditional logging with environment-controlled tracing.
+///
+/// The [Logger] class provides static methods to emit log messages to
+/// `stderr` based on a runtime environment variable.
+/// Logging is only enabled when the `PIXEL_PROMPT_TRACING` environment
+/// variable is set to `'1'`.
+///
+/// Output is written to `stderr` with a structured format that includes:
+/// - A log level prefix (e.g., TRACE, DEBUG, INFO)
+/// - An ISO 8601 timestamp
+/// - A user-defined tag
+/// - The message content
+///
+/// This is especially useful for separating debug logs from golden file output
+/// or other stdout-driven content.
+///
+/// Example usage:
+/// ```dart
+/// Logger.debug('RenderPipeline', 'Component rendered');
+/// ```
+///
+/// No logs are written if tracing is disabled.
 class Logger {
+  /// Whether logging is currently enabled based on the
+  /// `PIXEL_PROMPT_TRACING` environment variable.
   static final bool _enabled =
       Platform.environment['PIXEL_PROMPT_TRACING'] == '1';
 
+  /// Internal method to emit a log line with the given [level], [tag], and [msg].
+  ///
+  /// If logging is disabled, this method returns immediately.
+  /// Otherwise, the message is formatted and written to `stderr`.
   static void _log(String level, String tag, String msg) {
     if (!_enabled) return;
 
     final timeStamp = DateTime.now().toIso8601String();
-
-    // wrote in stderr to avoid writing logs inside golden file and for easier distinction when debugging
     stderr.write('==PIXEL_PROMPT_TRACING_$level==[$timeStamp][$tag] $msg\n');
   }
 
+  /// Emits a trace-level log with the given [tag] and [msg].
   static void trace(String tag, String msg) => _log('TRACE', tag, msg);
+
+  /// Emits a debug-level log with the given [tag] and [msg].
   static void debug(String tag, String msg) => _log('DEBUG', tag, msg);
+
+  /// Emits an info-level log with the given [tag] and [msg].
   static void info(String tag, String msg) => _log('INFO', tag, msg);
+
+  /// Emits a warning-level log with the given [tag] and [msg].
   static void warn(String tag, String msg) => _log('WARN', tag, msg);
+
+  /// Emits an error-level log with the given [tag] and [msg].
   static void error(String tag, String msg) => _log('ERROR', tag, msg);
 }

--- a/lib/manager/focus_manager.dart
+++ b/lib/manager/focus_manager.dart
@@ -119,7 +119,7 @@ class FocusManager implements InputHandler {
   }
 
   bool _isWithinBounds(int x, int y, InteractableComponent component) {
-    final bounds = component.getBounds();
+    final bounds = component.bounds;
 
     final adjustedX = bounds.x + context.cursorX;
     final adjustedY = bounds.y + context.cursorY;

--- a/lib/renderer/render_manager.dart
+++ b/lib/renderer/render_manager.dart
@@ -17,9 +17,9 @@ class RenderManager {
 
   void requestRedraw() {
     for (var component in _dirtyComponents) {
-      buffer.clearBufferArea(component.getBounds());
-      buffer.flushArea(component.getBounds());
-      component.render(buffer, component.getBounds());
+      buffer.clearBufferArea(component.bounds);
+      buffer.flushArea(component.bounds);
+      component.render(buffer, component.bounds);
     }
 
     _dirtyComponents.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ repository: https://github.com/primequantuM4/pixel_prompt
 issue_tracker: https://github.com/primequantuM4/pixel_prompt/issues
 
 dependencies:
+  dartdoc: ^8.3.4
   ffi: ^2.1.4
   win32: ^5.14.0
   # path: ^1.8.0


### PR DESCRIPTION
### Summary

This PR adds documentation comments across major framework files to enable proper Dartdoc generation. Includes:

- `App`, `CanvasBuffer`, `Component`, `InteractableComponent`, etc.
- Positioning and sizing types (`Rect`, `Size`, `Position`)
- Logger and RenderManager
### Updated
- `RenderManager` and `Layout Engine` to use getter and setter of `Component.bounds` 
### Motivation
- Improve internal readability
- Prepare the codebase for external usage or contribution
- Enable clean auto-generated documentation with `dart doc`

Pr focuses on Documentation
