### PR TITLE
fix: Focus to retain position after screen is redrawn with `setState`

### DIFF
--- a/lib/components/button_component.dart
+++ b/lib/components/button_component.dart
@@ -157,7 +157,6 @@ class _ButtonComponentInstance extends InteractableComponentInstance {
     if (event.code == KeyCode.enter || (event.char == ' ')) {
       Logger.trace("ButtonComponent", "Triggering On Pressed");
       component.onPressed.call();
-      onBlur();
       return ResponseInput(
         handled: true,
         commands: ResponseCommands.none,
@@ -216,8 +215,6 @@ class _ButtonComponentInstance extends InteractableComponentInstance {
 
   @override
   void onClick() {
-    isFocused = false;
-    isHovered = false;
     component.onPressed.call();
   }
 

--- a/lib/core/context.dart
+++ b/lib/core/context.dart
@@ -1,9 +1,50 @@
-//TODO: Generate DocString once context becomes more involved
+import 'package:pixel_prompt/core/interactable_component_instance.dart';
+
+/// Maintains the state of user interaction within a UI context.
+///
+/// The [Context] class tracks the cursor position and manages interactive
+/// components that can receive focus or hover states. It acts as a central
+/// store for determining which component should respond to keyboard or mouse
+/// input at any given time.
 class Context {
+  /// Current X position of the cursor in the UI.
+  ///
+  /// Defaults to `-1` if not set.
   int cursorX = -1;
+
+  /// Current Y position of the cursor in the UI.
+  ///
+  /// Defaults to `-1` if not set.
   int cursorY = -1;
 
-  setInitialCursorPosition(int x, int y) {
+  /// All interactive components registered for focus and hover tracking.
+  ///
+  /// Components in this list may receive focus or hover state changes,
+  /// and are indexed by [currentComponentIndex].
+  final List<InteractableComponentInstance> componentInstances = [];
+
+  /// Index of the [currentComponent] in [componentInstances].
+  ///
+  /// A value of `-1` indicates that no component is currently focused.
+  int currentComponentIndex = -1;
+
+  /// The component that currently has keyboard focus, if any.
+  ///
+  /// `null` if no component is focused.
+  InteractableComponentInstance? currentComponent;
+
+  /// The component currently under the mouse cursor (hovered), if any.
+  ///
+  /// `null` if no component is hovered.
+  InteractableComponentInstance? hoveredComponent;
+
+  /// Sets the initial cursor position within the UI.
+  ///
+  /// Useful for initializing cursor state before any interactions occur.
+  ///
+  /// - [x]: The horizontal position of the cursor.
+  /// - [y]: The vertical position of the cursor.
+  void setInitialCursorPosition(int x, int y) {
     cursorX = x;
     cursorY = y;
   }

--- a/lib/manager/component_input_handler.dart
+++ b/lib/manager/component_input_handler.dart
@@ -42,7 +42,7 @@ class ComponentInputHandler implements InputHandler {
   /// returns [ResponseInput.ignored].
   @override
   ResponseInput handleInput(InputEvent event) {
-    final focused = _focusManager.currentComponent;
+    final focused = _focusManager.context.currentComponent;
 
     if (focused == null) {
       return ResponseInput.ignored();


### PR DESCRIPTION
## Summary
This PR fixes an issue where focus was lost after calling `setState`, 
causing input components to reset unexpectedly. Focus and hover 
management have been centralized into `Context`, ensuring that the 
currently focused component is retained across redraws.

## Changes
- **Context**
  - Added tracking for `currentComponent`, `currentComponentIndex`, and `hoveredComponent`.
  - Documented `Context` fields and methods.
- **FocusManager**
  - Delegated focus/hover state to `Context` instead of storing local copies.
  - Ensures that re-registering components after rebuild restores focus 
    to the correct one.
- **ComponentInputHandler**
  - Updated to reference `context.currentComponent` for input handling.
- **ButtonComponent & other interactive components**
  - Integrated with new context-driven focus handling.