### PR TITLE
fix: Hovered components to not leave artifcats when `setState` is called

### DIFF
--- a/lib/manager/focus_manager.dart
+++ b/lib/manager/focus_manager.dart
@@ -81,6 +81,7 @@ class FocusManager implements InputHandler {
   /// the UI to avoid dangling references.
   void reset() {
     context.componentInstances.clear();
+    context.hoveredComponent = null;
   }
 
   /// Handles cycling focus forward (`Tab`) or backward (`Shift+Tab`).


### PR DESCRIPTION
Bug fix for seeing artifacts