### PR TITLE
feature: SizedBox, Center components & rendering fix

### DIFF
--- a/example/sized_box_demo/sized_box_demo.dart
+++ b/example/sized_box_demo/sized_box_demo.dart
@@ -1,31 +1,26 @@
 import 'dart:async';
 
+import 'package:pixel_prompt/components/sized_box_style.dart';
 import 'package:pixel_prompt/core/size.dart';
 import 'package:pixel_prompt/pixel_prompt.dart';
 import 'package:pixel_prompt/terminal/terminal_functions.dart';
-
-// This demo will be enhanced when Expanded, Center and BorderBox
-// are added.
+import 'package:pixel_prompt/components/center.dart';
 
 // Let's create a count box, which will count numbers for us
 class CountBox extends StatefulComponent {
   final int countStart;
   final Size boxSize;
   final bool isBackwards;
-  final EdgeInsets margin;
-  final EdgeInsets pad;
 
   CountBox({
     required this.boxSize,
     this.countStart = 0,
     this.isBackwards = false,
-    this.margin = const EdgeInsets.all(0),
-    this.pad = const EdgeInsets.all(0),
   });
 
   @override
   ComponentState<CountBox> createState() =>
-      _CountBoxState(countStart, boxSize, isBackwards, margin, pad);
+      _CountBoxState(countStart, boxSize, isBackwards);
 }
 
 // State is a must-have for such a component (number being counted is *the* state)
@@ -33,15 +28,8 @@ class _CountBoxState extends ComponentState<CountBox> {
   int count;
   final Size boxSize;
   final bool isBackwards;
-  final EdgeInsets margin, padding;
 
-  _CountBoxState(
-    this.count,
-    this.boxSize,
-    this.isBackwards,
-    this.margin,
-    this.padding,
-  );
+  _CountBoxState(this.count, this.boxSize, this.isBackwards);
 
   @override
   void initState() {
@@ -57,42 +45,90 @@ class _CountBoxState extends ComponentState<CountBox> {
 
   @override
   List<Component> build() {
-    return [
-      SizedBox(
-        child: TextComponent(count.toString()),
-        size: boxSize,
-        margin: margin,
-        padding: padding,
-      ),
-    ];
+    return [SizedBox(child: TextComponent(count.toString()), size: boxSize)];
   }
 }
 
 void main() {
-  // Won't resize on terminal resize, keep in mind.
-  final Size halved = Size(
+  final Size smallSized = Size(
     width: TerminalFunctions.terminalWidth ~/ 2,
-    height: TerminalFunctions.terminalHeight ~/ 2,
+    height: TerminalFunctions.terminalHeight ~/ 4,
   );
-
-  var box1 = CountBox(boxSize: halved);
-  var box2 = SizedBox(
-    child: TextComponent("I'm on the right side!"),
-    size: halved,
-  );
-  var box3 = SizedBox(
-    child: TextComponent("And I'm on the left side! (Padded)"),
-    size: halved,
-    padding: EdgeInsets.all(2),
-  );
-  var box4 = CountBox(boxSize: halved, countStart: 100, isBackwards: true);
 
   App(
     children: [
       Column(
         children: [
-          Row(children: [box1, box2]),
-          Row(children: [box3, box4]),
+          Row(
+            children: [
+              SizedBox(
+                size: smallSized,
+                padding: EdgeInsets.all(1),
+                child: CountBox(boxSize: smallSized),
+              ),
+              SizedBox(
+                size: smallSized,
+                padding: EdgeInsets.all(1),
+                child: TextComponent(
+                  "I'm on the right side!",
+                  style: TextComponentStyle(color: Colors.blue),
+                ),
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              SizedBox(
+                size: smallSized,
+                padding: EdgeInsets.all(2),
+                child: TextComponent(
+                  "And I'm on the left side! (Padded)",
+                  style: TextComponentStyle(color: Colors.green),
+                ),
+              ),
+              SizedBox(
+                size: smallSized,
+                padding: EdgeInsets.all(1),
+                child: CountBox(
+                  boxSize: smallSized,
+                  countStart: 100,
+                  isBackwards: true,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(
+            child: Center(
+              child: TextComponent(
+                "Centered Text",
+                style: TextComponentStyle(
+                  color: Colors.green,
+                  bgColor: Colors.white,
+                ),
+              ),
+            ),
+            size: Size(
+              height: TerminalFunctions.terminalHeight ~/ 4,
+              width: TerminalFunctions.terminalWidth,
+            ),
+            style: SizedBoxStyle(border: BorderStyle.thick),
+          ),
+          SizedBox(
+            size: Size(
+              height: TerminalFunctions.terminalHeight ~/ 4,
+              width: TerminalFunctions.terminalWidth,
+            ),
+            style: SizedBoxStyle(
+              backgroundColor: Colors.blue,
+              border: BorderStyle.rounded,
+            ),
+            child: Center(
+              child: TextComponent(
+                "Pretty Styled SizedBox",
+                style: TextComponentStyle(color: Colors.white),
+              ),
+            ),
+          ),
         ],
       ),
     ],

--- a/example/sized_box_demo/sized_box_demo.dart
+++ b/example/sized_box_demo/sized_box_demo.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:pixel_prompt/core/size.dart';
+import 'package:pixel_prompt/pixel_prompt.dart';
+import 'package:pixel_prompt/terminal/terminal_functions.dart';
+
+// This demo will be enhanced when Expanded, Center and BorderBox
+// are added.
+
+// Let's create a count box, which will count numbers for us
+class CountBox extends StatefulComponent {
+  final int countStart;
+  final Size boxSize;
+  final bool isBackwards;
+  final EdgeInsets margin;
+  final EdgeInsets pad;
+
+  CountBox({
+    required this.boxSize,
+    this.countStart = 0,
+    this.isBackwards = false,
+    this.margin = const EdgeInsets.all(0),
+    this.pad = const EdgeInsets.all(0),
+  });
+
+  @override
+  ComponentState<CountBox> createState() =>
+      _CountBoxState(countStart, boxSize, isBackwards, margin, pad);
+}
+
+// State is a must-have for such a component (number being counted is *the* state)
+class _CountBoxState extends ComponentState<CountBox> {
+  int count;
+  final Size boxSize;
+  final bool isBackwards;
+  final EdgeInsets margin, padding;
+
+  _CountBoxState(
+    this.count,
+    this.boxSize,
+    this.isBackwards,
+    this.margin,
+    this.padding,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+
+    Timer.periodic(
+      const Duration(seconds: 1),
+      (_) => setState(() {
+        count += (isBackwards) ? -1 : 1;
+      }),
+    );
+  }
+
+  @override
+  List<Component> build() {
+    return [
+      SizedBox(
+        child: TextComponent(count.toString()),
+        size: boxSize,
+        margin: margin,
+        padding: padding,
+      ),
+    ];
+  }
+}
+
+void main() {
+  // Won't resize on terminal resize, keep in mind.
+  final Size halved = Size(
+    width: TerminalFunctions.terminalWidth ~/ 2,
+    height: TerminalFunctions.terminalHeight ~/ 2,
+  );
+
+  var box1 = CountBox(boxSize: halved);
+  var box2 = SizedBox(
+    child: TextComponent("I'm on the right side!"),
+    size: halved,
+  );
+  var box3 = SizedBox(
+    child: TextComponent("And I'm on the left side! (Padded)"),
+    size: halved,
+    padding: EdgeInsets.all(2),
+  );
+  var box4 = CountBox(boxSize: halved, countStart: 100, isBackwards: true);
+
+  App(
+    children: [
+      Column(
+        children: [
+          Row(children: [box1, box2]),
+          Row(children: [box3, box4]),
+        ],
+      ),
+    ],
+  ).run(fullScreenMode: true);
+}

--- a/lib/components/center.dart
+++ b/lib/components/center.dart
@@ -1,0 +1,76 @@
+import 'package:pixel_prompt/core/component_instance.dart';
+import 'package:pixel_prompt/core/parent_component_instance.dart';
+import 'package:pixel_prompt/core/size.dart';
+import 'package:pixel_prompt/pixel_prompt.dart';
+
+/// A component that centers its [child] within the available space.
+///
+/// The [Center] component attempts to size itself to the largest possible
+/// extent in its parent, and then centers its [child] within that space.
+/// If the child is larger than the available space, the child will be
+/// clipped.
+///
+/// Example:
+/// ```dart
+/// Center(
+///   child: TextComponent('Centered Text'),
+/// );
+/// ```
+///
+/// {@category Components}
+class Center extends Component {
+  /// The component to be centered.
+  final Component child;
+
+  /// Creates a [Center] component with the given [child].
+  const Center({required this.child});
+
+  @override
+  ComponentInstance createInstance() => _CenterInstance(component: this);
+}
+
+/// The runtime instance of a [Center] component.
+///
+/// This class manages the layout and rendering of the [Center] component
+/// at runtime, ensuring its child is centered within the available bounds.
+///
+class _CenterInstance extends ParentComponentInstance {
+  /// The child component instance to be centered.
+  final ComponentInstance _childInstance;
+
+  /// Creates a [_CenterInstance] for the given [Center] component.
+  _CenterInstance({required Center component})
+    : _childInstance = component.child.createInstance(),
+      super(component);
+
+  @override
+  List<ComponentInstance> get childrenInstance => [_childInstance];
+
+  @override
+  Size measure(Size maxSize) => maxSize;
+
+  @override
+  int fitHeight() => _childInstance.fitHeight();
+
+  @override
+  int fitWidth() => _childInstance.fitWidth();
+
+  @override
+  void render(CanvasBuffer buffer, Rect bounds) {
+    final childSize = _childInstance.measure(
+      Size(width: bounds.width, height: bounds.height),
+    );
+
+    final double offsetX = (bounds.width - childSize.width) / 2;
+    final double offsetY = (bounds.height - childSize.height) / 2;
+
+    final childRect = Rect(
+      x: bounds.x + offsetX.toInt(),
+      y: bounds.y + offsetY.toInt(),
+      width: childSize.width,
+      height: childSize.height,
+    );
+
+    _childInstance.render(buffer, childRect);
+  }
+}

--- a/lib/components/sized_box.dart
+++ b/lib/components/sized_box.dart
@@ -1,0 +1,62 @@
+import 'package:pixel_prompt/core/component_instance.dart';
+import 'package:pixel_prompt/core/size.dart';
+import 'package:pixel_prompt/pixel_prompt.dart';
+
+class SizedBox extends Component {
+  final Component child;
+
+  final Size size;
+  final EdgeInsets margin;
+
+  const SizedBox({
+    required this.child,
+    required this.size,
+    this.margin = const EdgeInsets.all(0),
+    super.padding,
+  });
+
+  @override
+  ComponentInstance createInstance() =>
+      _SizedBoxInstance(child, size, padding: padding, margin: margin);
+}
+
+class _SizedBoxInstance extends ComponentInstance {
+  final ComponentInstance _childInstance;
+
+  final Size size;
+  final EdgeInsets margin;
+
+  _SizedBoxInstance(
+    Component child,
+    this.size, {
+    super.padding,
+    this.margin = const EdgeInsets.all(0),
+  }) : _childInstance = child.createInstance();
+
+  @override
+  Size measure(Size maxSize) {
+    return Size(
+      width: size.width + margin.horizontal,
+      height: size.height + margin.vertical,
+    );
+  }
+
+  @override
+  int fitHeight() => size.height + margin.vertical;
+
+  @override
+  int fitWidth() => size.width + margin.horizontal;
+
+  @override
+  void render(CanvasBuffer buffer, Rect bounds) {
+    _childInstance.render(
+      buffer,
+      Rect(
+        x: bounds.x + padding.left,
+        y: bounds.y + padding.top,
+        width: bounds.width - padding.right,
+        height: bounds.bottom - padding.bottom,
+      ),
+    );
+  }
+}

--- a/lib/components/sized_box.dart
+++ b/lib/components/sized_box.dart
@@ -1,37 +1,96 @@
+import 'package:pixel_prompt/components/sized_box_style.dart';
 import 'package:pixel_prompt/core/component_instance.dart';
 import 'package:pixel_prompt/core/size.dart';
 import 'package:pixel_prompt/pixel_prompt.dart';
+import 'package:pixel_prompt/renderer/border_renderer.dart';
 
+/// A component that provides a fixed [size] constraint for its child.
+///
+/// The [SizedBox] component is used to impose specific [width] and [height]
+/// constraints on its [child]. If the child component is smaller than the
+/// specified [size], the [SizedBox] will fill the remaining space with
+/// whitespace. It does not force the child to expand to fill the entire box,
+/// but rather limits the maximum available space for the child.
+///
+/// This is particularly useful for:
+/// - Creating fixed-size spacers or gaps in layouts.
+/// - Providing a maximum size constraint for a child, while allowing it to be smaller.
+/// - Ensuring consistent sizing for interactive elements like buttons or text fields.
+///
+/// The [margin] property adds empty space around the [SizedBox] itself,
+/// effectively pushing other components away. The [padding] property adds
+/// empty space *inside* the [SizedBox], between its own border and its [child].
+///
+/// Example:
+/// ```dart
+/// SizedBox(
+///   size: Size(width: 10, height: 5),
+///   margin: EdgeInsets.all(1),
+///   padding: EdgeInsets.symmetric(horizontal: 1, vertical: 0),
+///   child: TextComponent('Limited Size'),
+/// );
+/// ```
+///
+/// See also:
+/// - [Size], for defining the width and height.
+/// - [EdgeInsets], for defining margins and paddings.
+///
+/// {@category Components}
 class SizedBox extends Component {
+  /// The component to be constrained by this [SizedBox].
   final Component child;
 
+  /// The fixed [Size] that this [SizedBox] will provide as a constraint to its child.
+  /// If the child is smaller, the remaining space will be filled with whitespace.
   final Size size;
+
+  /// Empty space to inscribe around the [SizedBox].
+  ///
+  /// The [margin] is added to the total size of the [SizedBox] when measured
+  /// by its parent.
   final EdgeInsets margin;
 
+  /// The style to apply to the [SizedBox], including background color and border.
+  final SizedBoxStyle? style;
+
+  /// Creates a [SizedBox] with a specific [size] for its [child].
+  ///
+  /// The [child] and [size] parameters are required. The [margin] defaults
+  /// to [EdgeInsets.all(0)] if not provided.
   const SizedBox({
     required this.child,
     required this.size,
     this.margin = const EdgeInsets.all(0),
+    this.style,
     super.padding,
   });
 
   @override
   ComponentInstance createInstance() =>
-      _SizedBoxInstance(child, size, padding: padding, margin: margin);
+      _SizedBoxInstance(this, size, padding: padding, margin: margin, style: style);
 }
 
+/// The runtime instance of a [SizedBox] component.
+///
+/// This class manages the layout and rendering of the [SizedBox] at runtime.
+/// It ensures that the child component is rendered within the specified [size]
+/// and applies any [margin] or [padding] defined by the [SizedBox].
+///
+/// {@category Components}
 class _SizedBoxInstance extends ComponentInstance {
   final ComponentInstance _childInstance;
 
   final Size size;
   final EdgeInsets margin;
+  final SizedBoxStyle? style;
 
   _SizedBoxInstance(
-    Component child,
+    SizedBox component,
     this.size, {
     super.padding,
     this.margin = const EdgeInsets.all(0),
-  }) : _childInstance = child.createInstance();
+    this.style,
+  }) : _childInstance = component.child.createInstance();
 
   @override
   Size measure(Size maxSize) {
@@ -49,14 +108,36 @@ class _SizedBoxInstance extends ComponentInstance {
 
   @override
   void render(CanvasBuffer buffer, Rect bounds) {
-    _childInstance.render(
-      buffer,
-      Rect(
-        x: bounds.x + padding.left,
-        y: bounds.y + padding.top,
-        width: bounds.width - padding.right,
-        height: bounds.bottom - padding.bottom,
-      ),
-    );
+    if (style?.backgroundColor != null) {
+      buffer.fill(bounds, style!.backgroundColor!);
+    }
+
+    if (style?.border != null) {
+      final borderRenderer = BorderRenderer(
+        style: style!.border!,
+        borderColor: style!.backgroundColor,
+      );
+      borderRenderer.draw(buffer, bounds, (buffer, innerBounds) {
+        _childInstance.render(
+          buffer,
+          Rect(
+            x: innerBounds.x + padding.left,
+            y: innerBounds.y + padding.top,
+            width: innerBounds.width - padding.horizontal,
+            height: innerBounds.height - padding.vertical,
+          ),
+        );
+      });
+    } else {
+      _childInstance.render(
+        buffer,
+        Rect(
+          x: bounds.x + padding.left,
+          y: bounds.y + padding.top,
+          width: bounds.width - padding.horizontal,
+          height: bounds.height - padding.vertical,
+        ),
+      );
+    }
   }
 }

--- a/lib/components/sized_box_style.dart
+++ b/lib/components/sized_box_style.dart
@@ -1,0 +1,52 @@
+import 'package:pixel_prompt/components/border_style.dart';
+import 'package:pixel_prompt/components/colors.dart';
+
+/// Defines the visual style for a [SizedBox] component, including its
+/// background color and border.
+///
+/// A [SizedBoxStyle] encapsulates the styling information that determines
+/// how a [SizedBox] is displayed in the terminal.
+///
+/// ### Styling Options
+/// - **Background Color:** Controlled by [backgroundColor] using [AnsiColorType].
+/// - **Border:** Controlled by [border] using [BorderStyle].
+///
+/// ### Example
+/// ```dart
+/// final style = SizedBoxStyle(
+///   backgroundColor: Colors.blue,
+///   border: BorderStyle.solid,
+/// );
+/// ```
+///
+/// ### See Also
+/// - [AnsiColorType] for color definitions.
+/// - [BorderStyle] for border definitions.
+///
+/// {@category Styling}
+class SizedBoxStyle {
+  /// The background color of the [SizedBox].
+  final AnsiColorType? backgroundColor;
+
+  /// The border style of the [SizedBox].
+  final BorderStyle? border;
+
+  /// Creates a [SizedBoxStyle] with an optional background color and border.
+  const SizedBoxStyle({
+    this.backgroundColor,
+    this.border,
+  });
+
+  /// Returns a new [SizedBoxStyle] with the given properties overridden.
+  ///
+  /// Properties not specified will be copied from the current style.
+  SizedBoxStyle copyWith({
+    AnsiColorType? backgroundColor,
+    BorderStyle? border,
+  }) {
+    return SizedBoxStyle(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      border: border ?? this.border,
+    );
+  }
+}

--- a/lib/core/canvas_buffer.dart
+++ b/lib/core/canvas_buffer.dart
@@ -189,6 +189,19 @@ class CanvasBuffer {
     }
   }
 
+  /// Fills a rectangular [area] with a specified [backgroundColor].
+  ///
+  /// All cells within [area] will have their background color set to [backgroundColor].
+  void fill(Rect area, AnsiColorType backgroundColor) {
+    for (int line = area.y; line < area.y + area.height; line++) {
+      if (line >= _screenBuffer.length) break;
+      for (int column = area.x; column < area.x + area.width; column++) {
+        if (column >= _screenBuffer[0].length) break;
+        _screenBuffer[line][column].bg = backgroundColor;
+      }
+    }
+  }
+
   /// Flushes the contents of a rectangular [area] to the terminal.
   ///
   /// This writes spaces over the specified area at the current cursor position,

--- a/lib/core/stateful_component.dart
+++ b/lib/core/stateful_component.dart
@@ -180,9 +180,10 @@ class StatefulComponentInstance extends ParentComponentInstance {
   /// Logs each render action for tracing via [Logger.trace].
   @override
   void render(CanvasBuffer buffer, Rect bounds) {
+    this.bounds = bounds;
     for (final child in childrenInstance) {
       Logger.trace("StatefulComponent", "Item $child is being rendered");
-      child.render(buffer, child.bounds);
+      child.render(buffer, bounds);
     }
   }
 }

--- a/lib/pixel_prompt.dart
+++ b/lib/pixel_prompt.dart
@@ -12,6 +12,7 @@ export 'components/checkbox.dart';
 export 'components/border_style.dart';
 export 'components/text_field_component.dart';
 export 'components/button_component.dart';
+export 'components/sized_box.dart';
 export 'core/app.dart';
 export 'core/stateful_component.dart';
 export 'core/component_state.dart';


### PR DESCRIPTION
New:
**Center** component: allows to center child widgets, improving layout flexibility (Documented)
**SizedBox** component: a box of fixed size that has one child (useful for fixed layouts, Documented)
**CanvasBuffer.fill**: implemented a fill method for CanvasBuffer to support background coloring (Documented)
SizedBox **demo**: incorporates SizedBox and Center components in a simple showcase app

Rendering bug fix:
Resolved an issue in **StatefulComponentInstance.render** where child component bounds were accessed before being set (my demo was throwing exceptions because of that)